### PR TITLE
Fix willChangeOrientation bug

### DIFF
--- a/Sources/SwipeMenuView.swift
+++ b/Sources/SwipeMenuView.swift
@@ -264,6 +264,7 @@ open class SwipeMenuView: UIView {
     /// Notify changing orientaion to `SwipeMenuView` before it.
     public func willChangeOrientation() {
         isLayoutingSubviews = true
+        setNeedsLayout()
     }
 
     fileprivate func update(from fromIndex: Int, to toIndex: Int) {


### PR DESCRIPTION
### Problem

If `willChangeOrientation()` called when `swipeMenuView` is not appeared,  `layoutSubviews()` may not be called.
In that case,  `isLayoutingSubviews` keeps to true. various problems occur.
For example, `updateTabViewAddition(by:)` and `update(from:to:)` will not be called

Ref: https://github.com/yysskk/SwipeMenuViewController/blob/master/Sources/SwipeMenuView.swift#L408

### Solution

I added `setNeedsLayout()` in `willChangeOrientation()`.
`layoutSubviews` always be called.
