### PR TITLE
This fixes the issue that the underline wasn’t correct 

### DIFF
--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -406,8 +406,8 @@ extension TabView {
         guard let currentItem = currentItem else { return }
 
         if options.addition == .underline {
-            underlineView.frame.origin.x = currentItem.frame.origin.x
-            underlineView.frame.size.width = currentItem.frame.size.width
+            underlineView.frame.origin.x = currentItem.frame.origin.x + options.underlineView.margin
+            underlineView.frame.size.width = currentItem.frame.size.width - options.underlineView.margin * 2
         }
 
         focus(on: currentItem, animated: false)


### PR DESCRIPTION
when tabView is initially setup