### PR TITLE
Fix underbar position to specify default index

### DIFF
--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -124,7 +124,7 @@ open class TabView: UIScrollView {
         setupUnderlineView()
 
         if let defaultIndex = defaultIndex {
-            updateSelectedItem(by: defaultIndex)
+            moveTabItem(index: defaultIndex)
         }
     }
 


### PR DESCRIPTION
## Summary
 The position of the under bar does not move when specifying the default index of the tab.
