### PR TITLE
fix crash on viewWillTransition before viewDidLoad

### DIFF
--- a/Sources/Classes/SwipeMenuViewController.swift
+++ b/Sources/Classes/SwipeMenuViewController.swift
@@ -16,7 +16,9 @@ open class SwipeMenuViewController: UIViewController, SwipeMenuViewDelegate, Swi
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        swipeMenuView.willChangeOrientation()
+        // potentially nil.
+        // https://forums.developer.apple.com/thread/94426
+        swipeMenuView?.willChangeOrientation()
     }
 
     open override func viewDidLayoutSubviews() {


### PR DESCRIPTION
ref: https://forums.developer.apple.com/thread/94426

Could not reproduce in Example app.
I encountered crash when launched in iPad multitasking mode in my own project. (will publish code soon)