### PR TITLE
Monochrome color support added for tabview title color transition

### DIFF
--- a/Sources/Classes/UIColorExtension.swift
+++ b/Sources/Classes/UIColorExtension.swift
@@ -5,9 +5,17 @@ extension UIColor {
     func convert(to color: UIColor, multiplier _multiplier: CGFloat) -> UIColor? {
         let multiplier = min(max(_multiplier, 0), 1)
 
-        let components = cgColor.components ?? []
-        let toComponents = color.cgColor.components ?? []
+        var components = cgColor.components ?? []
+        var toComponents = color.cgColor.components ?? []
 
+        if cgColor.colorSpace!.model == CGColorSpaceModel.monochrome {
+            components = [ components[0], components[0], components[0], components[1]]
+        }
+        
+        if color.cgColor.colorSpace!.model == CGColorSpaceModel.monochrome {
+            toComponents = [ toComponents[0], toComponents[0], toComponents[0], toComponents[1]]
+        }
+        
         if components.isEmpty || components.count < 3 || toComponents.isEmpty || toComponents.count < 3 {
             return nil
         }


### PR DESCRIPTION
TabView title color transition did not support monochrome colors such as black, white and grays. So, I've modified the UIColor extension to support monochrome color transitions.