### PR TITLE
Update TabView to accept NSAttributedString

### DIFF
--- a/Sources/Classes/SwipeMenuView.swift
+++ b/Sources/Classes/SwipeMenuView.swift
@@ -177,7 +177,10 @@ public protocol SwipeMenuViewDataSource: class {
     func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int
 
     /// Return strings to be displayed at the tab in `SwipeMenuView`.
-    func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String?
+
+    /// Return attributed strings to be displayed at the tab in `SwipeMenuView`.
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, attributedTitleForPageAt index: Int) -> NSAttributedString?
 
     /// Return a ViewController to be displayed at the page in `SwipeMenuView`.
     func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewControllerForPageAt index: Int) -> UIViewController
@@ -398,6 +401,10 @@ extension SwipeMenuView: TabViewDelegate, TabViewDataSource {
 
     public func tabView(_ tabView: TabView, titleForItemAt index: Int) -> String? {
         return dataSource?.swipeMenuView(self, titleForPageAt: index)
+    }
+
+    public func tabView(_ tabView: TabView, attributedTitleForItemAt index: Int) -> NSAttributedString? {
+        return dataSource?.swipeMenuView(self, attributedTitleForPageAt: index)
     }
 }
 

--- a/Sources/Classes/SwipeMenuViewController.swift
+++ b/Sources/Classes/SwipeMenuViewController.swift
@@ -58,8 +58,12 @@ open class SwipeMenuViewController: UIViewController, SwipeMenuViewDelegate, Swi
         return children.count
     }
 
-    open func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String {
+    open func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String? {
         return children[index].title ?? ""
+    }
+
+    open func swipeMenuView(_ swipeMenuView: SwipeMenuView, attributedTitleForPageAt index: Int) -> NSAttributedString? {
+        return nil
     }
 
     open func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewControllerForPageAt index: Int) -> UIViewController {

--- a/Sources/Classes/TabView.swift
+++ b/Sources/Classes/TabView.swift
@@ -26,6 +26,9 @@ public protocol TabViewDataSource: class {
 
     /// Return strings to be displayed at the tab in `TabView`.
     func tabView(_ tabView: TabView, titleForItemAt index: Int) -> String?
+
+    /// Return attributed strings to be displayed at the tab in `TabView`.
+    func tabView(_ tabView: TabView, attributedTitleForItemAt index: Int) -> NSAttributedString?
 }
 
 open class TabView: UIScrollView {
@@ -216,6 +219,11 @@ open class TabView: UIScrollView {
             tabItemView.clipsToBounds = options.clipsToBounds
             if let title = dataSource.tabView(self, titleForItemAt: index) {
                 tabItemView.titleLabel.text = title
+                tabItemView.titleLabel.font = options.itemView.font
+                tabItemView.textColor = options.itemView.textColor
+                tabItemView.selectedTextColor = options.itemView.selectedTextColor
+            } else if let attributedTitle = dataSource.tabView(self, attributedTitleForItemAt: index) {
+                tabItemView.titleLabel.attributedText = attributedTitle
                 tabItemView.titleLabel.font = options.itemView.font
                 tabItemView.textColor = options.itemView.textColor
                 tabItemView.selectedTextColor = options.itemView.selectedTextColor


### PR DESCRIPTION
Here I update the `TabView` to accept `NSAttributedString` in lieu of `String`.

This enables quite a bit more flexibility with what you add as the title to the tab bar. For instance, one can now add images using the `NSTextAttachment`.

Regarding implementation, I have the `TabView` prefer `func tabView(_ tabView: TabView, titleForItemAt index: Int) -> String?` over `func tabView(_ tabView: TabView, attributedTitleForItemAt index: Int) -> NSAttributedString?`, so if you implement both dataSource methods for a given index it will use the original.