### PR TITLE
Replace Deprecated class-constrained Protocol with AnyObject

### DIFF
--- a/Sources/Classes/SwipeMenuView.swift
+++ b/Sources/Classes/SwipeMenuView.swift
@@ -147,7 +147,7 @@ public struct SwipeMenuViewOptions {
 
 // MARK: - SwipeMenuViewDelegate
 
-public protocol SwipeMenuViewDelegate: class {
+public protocol SwipeMenuViewDelegate: AnyObject {
 
     /// Called before setup self.
     func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewWillSetupAt currentIndex: Int)
@@ -171,7 +171,7 @@ extension SwipeMenuViewDelegate {
 
 // MARK: - SwipeMenuViewDataSource
 
-public protocol SwipeMenuViewDataSource: class {
+public protocol SwipeMenuViewDataSource: AnyObject {
 
     /// Return the number of pages in `SwipeMenuView`.
     func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int

--- a/Sources/Classes/TabView.swift
+++ b/Sources/Classes/TabView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - TabViewDelegate
 
-public protocol TabViewDelegate: class {
+public protocol TabViewDelegate: AnyObject {
 
     /// Called before selecting the tab.
     func tabView(_ tabView: TabView, willSelectTabAt index: Int)
@@ -19,7 +19,7 @@ extension TabViewDelegate {
 
 // MARK: - TabViewDataSource
 
-public protocol TabViewDataSource: class {
+public protocol TabViewDataSource: AnyObject {
 
     /// Return the number of Items in `TabView`.
     func numberOfItems(in tabView: TabView) -> Int


### PR DESCRIPTION
## Overview
This change replaces the usage of the `class` keyword to define a class-constrained protocol with `AnyObject`. This addresses the deprecation warning related to the `class` keyword.

## Changes Made
Updated the previous class-constrained protocol definition to use `AnyObject`.

### Before
```swift
protocol MyProtocol: class {
    // Protocol content
}
```

### After

```swift
protocol MyProtocol: AnyObject {
    // Protocol content
}
```
