### PR TITLE
Add a Swift Testing unit test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   package:
-    name: Package build (iOS Simulator)
+    name: Package tests (iOS Simulator)
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
@@ -25,12 +25,22 @@ jobs:
         run: |
           xcodebuild -version
           swift --version
-      - name: Build
+      - name: Select simulator
+        id: sim
+        run: |
+          DEVICE=$(xcrun simctl list devices available --json \
+            | jq -r '[.devices | to_entries[] | select(.key|test("iOS")) | .value[] | select(.isAvailable and (.name|startswith("iPhone")))][0].name // empty')
+          if [ -z "$DEVICE" ]; then sudo xcodebuild -downloadPlatform iOS; DEVICE=$(xcrun simctl list devices available --json | jq -r '[.devices|to_entries[]|select(.key|test("iOS"))|.value[]|select(.isAvailable and (.name|startswith("iPhone")))][0].name // empty'); fi
+          echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
+          echo "Using: $DEVICE"
+      - name: Test
         run: |
           set -o pipefail
-          xcodebuild build \
+          # The auto-generated `SwipeMenuViewController` scheme includes the
+          # test target, so it both builds the library and runs the tests.
+          xcodebuild test \
             -scheme SwipeMenuViewController \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.device }}" \
             CODE_SIGNING_ALLOWED=NO
 
   example:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           DEVICE=$(xcrun simctl list devices available --json \
             | jq -r '[.devices | to_entries[] | select(.key|test("iOS")) | .value[] | select(.isAvailable and (.name|startswith("iPhone")))][0].name // empty')
           if [ -z "$DEVICE" ]; then sudo xcodebuild -downloadPlatform iOS; DEVICE=$(xcrun simctl list devices available --json | jq -r '[.devices|to_entries[]|select(.key|test("iOS"))|.value[]|select(.isAvailable and (.name|startswith("iPhone")))][0].name // empty'); fi
+          if [ -z "$DEVICE" ]; then echo "::error::No available iPhone simulator found" >&2; exit 1; fi
           echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
           echo "Using: $DEVICE"
       - name: Test

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,13 @@ let package = Package(
             swiftSettings: [
                 .defaultIsolation(MainActor.self)
             ]
+        ),
+        .testTarget(
+            name: "SwipeMenuViewControllerTests",
+            dependencies: ["SwipeMenuViewController"],
+            swiftSettings: [
+                .defaultIsolation(MainActor.self)
+            ]
         )
     ]
 )

--- a/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+@MainActor
+@Suite("ContentScrollView", .serialized)
+struct ContentScrollViewTests {
+
+    @Test("Setup sizes the content width to one page per item")
+    func setupSizesContent() {
+        let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 0)
+        let dataSource = StubContentDataSource(pageCount: 4)
+        contentScrollView.dataSource = dataSource
+
+        let window = hostInWindow(contentScrollView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(abs(contentScrollView.contentSize.width - contentScrollView.frame.width * 4) < 0.5)
+
+        // Neighboring pages exist around the default (index 0): there is a next
+        // page but no previous page.
+        #expect(contentScrollView.currentPage != nil)
+        #expect(contentScrollView.previousPage == nil)
+        #expect(contentScrollView.nextPage != nil)
+    }
+
+    @Test("jump(to:animated:false) moves the content offset to the page")
+    func jumpUpdatesOffset() {
+        let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 0)
+        let dataSource = StubContentDataSource(pageCount: 4)
+        contentScrollView.dataSource = dataSource
+
+        let window = hostInWindow(contentScrollView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let pageWidth = contentScrollView.frame.width
+        #expect(pageWidth > 0)
+
+        contentScrollView.jump(to: 3, animated: false)
+        #expect(abs(contentScrollView.contentOffset.x - pageWidth * 3) < 0.5)
+
+        contentScrollView.jump(to: 1, animated: false)
+        #expect(abs(contentScrollView.contentOffset.x - pageWidth * 1) < 0.5)
+    }
+
+    @Test("A non-zero default index sets the matching current page")
+    func nonZeroDefaultIndex() throws {
+        let baseTag = 500
+        let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 2)
+        let dataSource = StubContentDataSource(pageCount: 4, baseTag: baseTag)
+        contentScrollView.dataSource = dataSource
+
+        let window = hostInWindow(contentScrollView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // The content spans all four pages regardless of the default index.
+        #expect(abs(contentScrollView.contentSize.width - contentScrollView.frame.width * 4) < 0.5)
+
+        // The current page corresponds to the default index, and it has both a
+        // previous and a next neighbor (index 2 of 0..<4).
+        let currentPage = try #require(contentScrollView.currentPage)
+        #expect(currentPage.tag == baseTag + 2)
+
+        let previousPage = try #require(contentScrollView.previousPage)
+        #expect(previousPage.tag == baseTag + 1)
+
+        let nextPage = try #require(contentScrollView.nextPage)
+        #expect(nextPage.tag == baseTag + 3)
+    }
+}

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -2,9 +2,10 @@ import Testing
 import UIKit
 @testable import SwipeMenuViewController
 
-/// Constructs a `SwipeMenuViewOptions` off the main actor to prove the type is
-/// usable from a `nonisolated` context (i.e. it really is `Sendable`).
-private nonisolated func makeOptionsOffMainActor() -> SwipeMenuViewOptions {
+/// Constructs a `SwipeMenuViewOptions` from a `nonisolated` context. That this
+/// compiles proves the type is usable outside the main actor (i.e. it really is
+/// `Sendable` and not main-actor isolated).
+private nonisolated func makeOptionsFromNonisolatedContext() -> SwipeMenuViewOptions {
     return SwipeMenuViewOptions()
 }
 
@@ -78,8 +79,9 @@ struct SwipeMenuViewOptionsTests {
         let sendable: any Sendable = SwipeMenuViewOptions()
         #expect(sendable is SwipeMenuViewOptions)
 
-        // And that it can be constructed off the main actor.
-        let offMain = makeOptionsOffMainActor()
-        #expect(offMain.tabView.height == 44.0)
+        // Compile-time proof that a nonisolated context can construct the
+        // options (the call itself still runs on the main actor here).
+        let fromNonisolated = makeOptionsFromNonisolatedContext()
+        #expect(fromNonisolated.tabView.height == 44.0)
     }
 }

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+/// Constructs a `SwipeMenuViewOptions` off the main actor to prove the type is
+/// usable from a `nonisolated` context (i.e. it really is `Sendable`).
+private nonisolated func makeOptionsOffMainActor() -> SwipeMenuViewOptions {
+    return SwipeMenuViewOptions()
+}
+
+@Suite("SwipeMenuViewOptions")
+struct SwipeMenuViewOptionsTests {
+
+    @Test("TabView documented defaults")
+    func tabViewDefaults() {
+        let options = SwipeMenuViewOptions()
+
+        #expect(options.tabView.height == 44.0)
+        #expect(options.tabView.margin == 0.0)
+        #expect(options.tabView.style == .flexible)
+        #expect(options.tabView.addition == .underline)
+        #expect(options.tabView.needsAdjustItemViewWidth == true)
+        #expect(options.tabView.needsConvertTextColorRatio == true)
+        #expect(options.tabView.isSafeAreaEnabled == true)
+    }
+
+    @Test("ItemView documented defaults")
+    func itemViewDefaults() {
+        let options = SwipeMenuViewOptions()
+
+        #expect(options.tabView.itemView.width == 100.0)
+        #expect(options.tabView.itemView.margin == 5.0)
+        #expect(options.tabView.itemView.font == UIFont.boldSystemFont(ofSize: 14))
+        #expect(options.tabView.itemView.clipsToBounds == true)
+    }
+
+    @Test("AdditionView documented defaults")
+    func additionViewDefaults() {
+        let options = SwipeMenuViewOptions()
+
+        #expect(options.tabView.additionView.underline.height == 2.0)
+        #expect(options.tabView.additionView.animationDuration == 0.3)
+        #expect(options.tabView.additionView.isAnimationOnSwipeEnable == true)
+        #expect(options.tabView.additionView.padding == .zero)
+    }
+
+    @Test("ContentScrollView documented defaults")
+    func contentScrollViewDefaults() {
+        let options = SwipeMenuViewOptions()
+
+        #expect(options.contentScrollView.clipsToBounds == true)
+        #expect(options.contentScrollView.isScrollEnabled == true)
+        #expect(options.contentScrollView.isSafeAreaEnabled == true)
+    }
+
+    @Test("Top-level isSafeAreaEnabled default is true")
+    func isSafeAreaEnabledDefault() {
+        let options = SwipeMenuViewOptions()
+        #expect(options.isSafeAreaEnabled == true)
+    }
+
+    @Test("Setting isSafeAreaEnabled propagates to nested options")
+    func isSafeAreaEnabledPropagates() {
+        var options = SwipeMenuViewOptions()
+
+        options.isSafeAreaEnabled = false
+        #expect(options.tabView.isSafeAreaEnabled == false)
+        #expect(options.contentScrollView.isSafeAreaEnabled == false)
+
+        options.isSafeAreaEnabled = true
+        #expect(options.tabView.isSafeAreaEnabled == true)
+        #expect(options.contentScrollView.isSafeAreaEnabled == true)
+    }
+
+    @Test("Options are Sendable")
+    func optionsAreSendable() {
+        // Compile-time proof that the value can be treated as `any Sendable`.
+        let sendable: any Sendable = SwipeMenuViewOptions()
+        #expect(sendable is SwipeMenuViewOptions)
+
+        // And that it can be constructed off the main actor.
+        let offMain = makeOptionsOffMainActor()
+        #expect(offMain.tabView.height == 44.0)
+    }
+}

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+@MainActor
+@Suite("SwipeMenuView", .serialized)
+struct SwipeMenuViewTests {
+
+    // `SwipeMenuView.dataSource`/`delegate` are `weak`, so every test keeps a
+    // strong local reference alive across its assertions.
+
+    @Test("Hosting sets up tabView and contentScrollView with matching counts")
+    func setupOnHosting() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let tabView = try #require(view.tabView)
+        let contentScrollView = try #require(view.contentScrollView)
+
+        #expect(tabView.itemViews.count == 3)
+        // `pageViews` is fileprivate; verify the page count via the content
+        // width (one page-width per page) instead.
+        #expect(abs(contentScrollView.contentSize.width - contentScrollView.frame.width * 3) < 0.5)
+    }
+
+    @Test("Titles from the dataSource appear on tab item labels")
+    func dataSourcePlumbing() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let titles = ["First", "Second", "Third"]
+        let dataSource = StubMenuDataSource(titles: titles)
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let tabView = try #require(view.tabView)
+        #expect(tabView.itemViews.count == titles.count)
+        for (index, title) in titles.enumerated() {
+            #expect(tabView.itemViews[index].titleLabel.text == title)
+        }
+    }
+
+    @Test("jump(to:animated:false) moves the content offset to the target page")
+    func jumpUpdatesContentOffset() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let contentScrollView = try #require(view.contentScrollView)
+        let pageWidth = contentScrollView.frame.width
+        #expect(pageWidth > 0)
+
+        view.jump(to: 2, animated: false)
+
+        #expect(abs(contentScrollView.contentOffset.x - pageWidth * 2) < 0.5)
+    }
+
+    @Test("Delegate receives willSetup before didSetup")
+    func delegateSetupOrdering() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B"])
+        view.dataSource = dataSource
+        let delegate = RecordingMenuDelegate()
+        view.delegate = delegate
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource, delegate)) {} }
+
+        let will = try #require(delegate.events.firstIndex(of: .willSetup(0)))
+        let did = try #require(delegate.events.firstIndex(of: .didSetup(0)))
+        #expect(will < did)
+    }
+
+    @Test("reloadData(options:) applies a new tab height")
+    func reloadDataAppliesNewOptions() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        var newOptions = SwipeMenuViewOptions()
+        newOptions.tabView.height = 60
+
+        view.reloadData(options: newOptions)
+
+        #expect(view.options.tabView.height == 60)
+        let tabView = try #require(view.tabView)
+        #expect(tabView.options.height == 60)
+    }
+
+    @Test("Zero pages hosts without crashing and produces no items")
+    func zeroPages() {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: [])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // setup() always constructs the subviews, but with no data the tab has
+        // no item views and the content scroll view has no pages (zero width,
+        // no current page).
+        #expect(view.tabView?.itemViews.count == 0)
+        #expect(view.contentScrollView?.currentPage == nil)
+        if let contentScrollView = view.contentScrollView {
+            #expect(contentScrollView.contentSize.width == 0)
+        }
+    }
+}

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+@MainActor
+@Suite("TabView", .serialized)
+struct TabViewTests {
+
+    private func makeTabView(titles: [String], options: SwipeMenuViewOptions.TabView) -> (TabView, StubTabViewDataSource) {
+        var opts = options
+        // Keep tests deterministic regardless of the host window's safe area.
+        opts.isSafeAreaEnabled = false
+        let tabView = TabView(frame: CGRect(x: 0, y: 0, width: 375, height: opts.height), options: opts)
+        let dataSource = StubTabViewDataSource(titles: titles)
+        tabView.dataSource = dataSource
+        return (tabView, dataSource)
+    }
+
+    @Test("reloadData builds one item per title with the correct labels")
+    func reloadDataBuildsItems() {
+        let titles = ["One", "Two", "Three"]
+        // `TabView.dataSource` is weak; keep a strong reference for the test.
+        let (tabView, dataSource) = makeTabView(titles: titles, options: SwipeMenuViewOptions.TabView())
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.count == titles.count)
+        for (index, title) in titles.enumerated() {
+            #expect(tabView.itemViews[index].titleLabel.text == title)
+        }
+    }
+
+    @Test("The first item is selected after reload")
+    func firstItemSelected() {
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: SwipeMenuViewOptions.TabView())
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.first?.isSelected == true)
+        #expect(tabView.itemViews.dropFirst().allSatisfy { $0.isSelected == false })
+    }
+
+    @Test("Flexible style with fixed width uses options.itemView.width")
+    func flexibleFixedWidth() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .flexible
+        options.needsAdjustItemViewWidth = false
+        options.itemView.width = 100
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.count == 3)
+        for itemView in tabView.itemViews {
+            #expect(abs(itemView.frame.width - 100) < 0.5)
+        }
+    }
+
+    @Test("Segmented style divides the width roughly equally across items")
+    func segmentedEqualWidths() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .segmented
+        options.margin = 0
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C", "D"], options: options)
+
+        let window = hostTabView(tabView, width: 400)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.count == 4)
+
+        let widths = tabView.itemViews.map { $0.frame.width }
+        let expected = tabView.frame.width / 4
+
+        // Each item is roughly an equal share of the tab width...
+        for width in widths {
+            #expect(abs(width - expected) < 1.0)
+        }
+        // ...and together they span the full tab width.
+        let total = widths.reduce(0, +)
+        #expect(abs(total - tabView.frame.width) < 1.0)
+    }
+
+    /// Counts the plain (non-`TabItemView`) `UIView` subviews inside the tab's
+    /// container stack view. The underline/circle addition view is added there
+    /// as a plain `UIView`; the item views are `TabItemView`s. `additionView`
+    /// itself is `fileprivate`, so we detect it through the view hierarchy.
+    private func additionViewCount(in tabView: TabView) -> Int {
+        guard let container = tabView.subviews.first(where: { $0 is UIStackView }) else {
+            return 0
+        }
+        return container.subviews.filter { type(of: $0) == UIView.self }.count
+    }
+
+    @Test("Underline addition produces an addition view in the hierarchy")
+    func underlineAdditionExists() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.addition = .underline
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // The underline addition view is added to the container view hierarchy.
+        #expect(additionViewCount(in: tabView) == 1)
+    }
+
+    @Test("No addition leaves the addition view out of the hierarchy")
+    func noAdditionHasNoAdditionView() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.addition = .none
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // With `.none`, the addition view is never added to the container.
+        #expect(additionViewCount(in: tabView) == 0)
+    }
+}

--- a/Tests/SwipeMenuViewControllerTests/TestSupport.swift
+++ b/Tests/SwipeMenuViewControllerTests/TestSupport.swift
@@ -1,0 +1,162 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+// MARK: - SwipeMenuView stubs
+
+/// A configurable `SwipeMenuViewDataSource` for tests.
+///
+/// `numberOfPages` mirrors `titles.count`, `titleForPageAt` returns the
+/// corresponding title, and `viewControllerForPageAt` vends a fresh
+/// `UIViewController` whose `title` matches the page's title.
+final class StubMenuDataSource: SwipeMenuViewDataSource {
+
+    var titles: [String]
+
+    init(titles: [String]) {
+        self.titles = titles
+    }
+
+    func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int {
+        return titles.count
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String {
+        return titles[index]
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewControllerForPageAt index: Int) -> UIViewController {
+        let vc = UIViewController()
+        vc.title = titles[index]
+        return vc
+    }
+}
+
+/// A `SwipeMenuViewDelegate` that records an ordered log of the lifecycle and
+/// paging callbacks it receives.
+final class RecordingMenuDelegate: SwipeMenuViewDelegate {
+
+    enum Event: Equatable {
+        case willSetup(Int)
+        case didSetup(Int)
+        case willChange(from: Int, to: Int)
+        case didChange(from: Int, to: Int)
+    }
+
+    private(set) var events: [Event] = []
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewWillSetupAt currentIndex: Int) {
+        events.append(.willSetup(currentIndex))
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewDidSetupAt currentIndex: Int) {
+        events.append(.didSetup(currentIndex))
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, willChangeIndexFrom fromIndex: Int, to toIndex: Int) {
+        events.append(.willChange(from: fromIndex, to: toIndex))
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, didChangeIndexFrom fromIndex: Int, to toIndex: Int) {
+        events.append(.didChange(from: fromIndex, to: toIndex))
+    }
+}
+
+// MARK: - TabView stub
+
+/// A configurable `TabViewDataSource` for tests.
+final class StubTabViewDataSource: TabViewDataSource {
+
+    var titles: [String]
+
+    init(titles: [String]) {
+        self.titles = titles
+    }
+
+    func numberOfItems(in tabView: TabView) -> Int {
+        return titles.count
+    }
+
+    func tabView(_ tabView: TabView, titleForItemAt index: Int) -> String? {
+        return titles[index]
+    }
+}
+
+// MARK: - ContentScrollView stub
+
+/// A configurable `ContentScrollViewDataSource` for tests. Each vended page is
+/// tagged with `baseTag + index` so pages can be identified in assertions.
+final class StubContentDataSource: ContentScrollViewDataSource {
+
+    var pageCount: Int
+    let baseTag: Int
+
+    init(pageCount: Int, baseTag: Int = 100) {
+        self.pageCount = pageCount
+        self.baseTag = baseTag
+    }
+
+    func numberOfPages(in contentScrollView: ContentScrollView) -> Int {
+        return pageCount
+    }
+
+    func contentScrollView(_ contentScrollView: ContentScrollView, viewForPageAt index: Int) -> UIView? {
+        let view = UIView()
+        view.tag = baseTag + index
+        return view
+    }
+}
+
+// MARK: - Hosting helper
+
+/// Hosts `view` in a real window so that `didMoveToSuperview()` fires and layout
+/// runs. The returned window must be kept alive by the caller for the duration
+/// of the test.
+///
+/// The window is not made key/visible: these tests only need the view attached
+/// to a window and laid out at a known size, and keeping the window offscreen
+/// avoids sharing global key-window state across tests.
+@MainActor
+func hostInWindow(_ view: UIView, size: CGSize = CGSize(width: 375, height: 667)) -> UIWindow {
+    let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+    view.frame = CGRect(origin: .zero, size: size)
+    window.addSubview(view)
+    view.setNeedsLayout()
+    view.layoutIfNeeded()
+    return window
+}
+
+/// Hosts a bare `TabView` at a fixed size using explicit constraints (mirroring
+/// how `SwipeMenuView` lays out its tab view) so the tab view's frame does not
+/// collapse when it sets `translatesAutoresizingMaskIntoConstraints = false`.
+///
+/// After laying out, `reloadData()` is called explicitly so the item views are
+/// built against the final, stable frame. The returned window must be kept
+/// alive by the caller.
+@MainActor
+func hostTabView(_ tabView: TabView, width: CGFloat = 375) -> UIWindow {
+    let containerSize = CGSize(width: width, height: 667)
+    let window = UIWindow(frame: CGRect(origin: .zero, size: containerSize))
+    let container = UIView(frame: CGRect(origin: .zero, size: containerSize))
+    window.addSubview(container)
+
+    let height = tabView.options.height
+    tabView.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(tabView)
+    NSLayoutConstraint.activate([
+        tabView.topAnchor.constraint(equalTo: container.topAnchor),
+        tabView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+        tabView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        tabView.heightAnchor.constraint(equalToConstant: height)
+    ])
+
+    container.setNeedsLayout()
+    container.layoutIfNeeded()
+
+    // Rebuild items against the final frame (didMoveToSuperview may have run a
+    // reload while the frame was still collapsing).
+    tabView.reloadData()
+    container.layoutIfNeeded()
+
+    return window
+}


### PR DESCRIPTION
## Summary

The library previously had no automated tests, and CI only compiled the code. This PR adds a unit test target using the Swift Testing framework and wires it into CI so the package is tested on an iOS simulator on every push.

This establishes the baseline coverage that the upcoming bug-fix PR will extend with regression tests. Scoped to characterizing current, correct behavior — it does not touch the areas slated for bug fixes.

## Changes

- **Test target.** Added `SwipeMenuViewControllerTests` to `Package.swift` with main-actor default isolation, matching the library.
- **22 tests across 4 suites:**
  - `SwipeMenuViewOptions` — documented defaults and `isSafeAreaEnabled` propagation to the nested tab and content options, plus a `Sendable` compile-time check.
  - `SwipeMenuView` — setup on hosting, title plumbing to tab labels, `jump(to:animated:)` content offset, delegate setup ordering, `reloadData(options:)`, and zero-page safety.
  - `TabView` — item construction from the data source, flexible fixed-width and segmented equal-width layout, and addition-view presence for the underline/none styles.
  - `ContentScrollView` — page content sizing, `jump(to:animated:)` offsets, and non-zero default index.
- **CI.** The package job now runs `xcodebuild test` on an iOS simulator (selected dynamically to avoid device-name drift) instead of only building.

## Testing

- `xcodebuild test -scheme SwipeMenuViewController -destination 'platform=iOS Simulator,name=<iPhone>'` — 22/22 pass, verified stable across repeated runs.
- Example app still builds.

## Notes

Tests host views in an offscreen `UIWindow` and force layout with `layoutIfNeeded()`; all paging uses `animated: false` for determinism. Because `delegate`/`dataSource` are `weak`, each test holds a strong reference to its stub for the duration of the test.