### PR TITLE
Fix currentIndex drift on a programmatic jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed duplicate Auto Layout constraints being added on every layout pass in `SwipeMenuViewController`.
 - Fixed a potential crash in the default data source when `numberOfPages(in:)` returns more pages than there are child view controllers.
 - Fixed tab underline/text-color artifacts when swiping past the first or last tab.
+- Fixed `SwipeMenuView.jump(to:animated:)` leaving `currentIndex` and the delegate change callbacks out of sync with the content when jumping across more than one page, and made it ignore out-of-range indices (a negative index previously crashed).
 
 ## 4.1.0 - 2020-03-12
 - Added `circle` addition style with `cornerRadius` and `maskedCorners` options.

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -347,6 +347,10 @@ open class SwipeMenuView: UIView {
         // into empty space (or trapping on a negative index).
         guard (0..<pageCount).contains(index) else { return }
 
+        // If a previous animated jump is still in flight, finalize it first so
+        // its `willChange` is paired with a `didChange` before this jump begins.
+        finalizePendingJump()
+
         let fromIndex = currentIndex
 
         // The tab bar is repositioned immediately; only the content scroll honors `animated`.
@@ -366,14 +370,32 @@ open class SwipeMenuView: UIView {
         jumpingToIndex = index
         contentScrollView.jump(to: index, animated: animated)
 
-        if !animated {
+        if !animated && isJumping {
             // A non-animated offset change fires no
             // `scrollViewDidEndScrollingAnimation(_:)`, so finalize synchronously.
+            // The `isJumping` guard keeps this idempotent: interrupting a prior
+            // animated jump can make that offset change deliver the cancelled
+            // animation's end callback first, which already finalizes the jump.
             currentIndex = index
             jumpingToIndex = nil
             isJumping = false
             delegate?.swipeMenuView(self, didChangeIndexFrom: fromIndex, to: index)
         }
+    }
+
+    /// Completes a still-in-flight jump so its
+    /// ``SwipeMenuViewDelegate/swipeMenuView(_:willChangeIndexFrom:to:)`` is paired with a matching
+    /// `didChange` before a new jump starts. While a jump is animating, `isJumping` holds
+    /// ``currentIndex`` at the origin page, so `jumpingToIndex` is the page the interrupted jump was
+    /// heading to.
+    private func finalizePendingJump() {
+        guard isJumping, let pendingIndex = jumpingToIndex else { return }
+        if currentIndex != pendingIndex {
+            delegate?.swipeMenuView(self, didChangeIndexFrom: currentIndex, to: pendingIndex)
+            currentIndex = pendingIndex
+        }
+        jumpingToIndex = nil
+        isJumping = false
     }
 
     /// Notifies the view that an orientation change is about to occur so it can relayout.

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -342,7 +342,7 @@ open class SwipeMenuView: UIView {
     ///   - index: The index of the page to display.
     ///   - animated: Whether the content transition is animated.
     public func jump(to index: Int, animated: Bool) {
-        guard let tabView = tabView, let contentScrollView = contentScrollView else { return }
+        guard let tabView, let contentScrollView else { return }
         // Ignore indices that have no corresponding page rather than scrolling
         // into empty space (or trapping on a negative index).
         guard (0..<pageCount).contains(index) else { return }
@@ -489,8 +489,14 @@ extension SwipeMenuView: TabViewDelegate, TabViewDataSource {
 
     public func tabView(_ tabView: TabView, didSelectTabAt index: Int) {
 
-        guard let contentScrollView = contentScrollView,
-            currentIndex != index else { return }
+        guard let contentScrollView else { return }
+
+        // Finalize any in-flight jump first so its `willChange` is paired with a
+        // `didChange` before this selection starts (a tap can interrupt an
+        // animated `jump(to:)` because the tab bar stays interactive during it).
+        finalizePendingJump()
+
+        guard currentIndex != index else { return }
 
         isJumping = true
         jumpingToIndex = index

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -333,18 +333,47 @@ open class SwipeMenuView: UIView {
     }
 
     /// Moves directly to the given page.
+    ///
+    /// After the call, ``currentIndex`` equals `index` and the delegate receives exactly one
+    /// ``SwipeMenuViewDelegate/swipeMenuView(_:willChangeIndexFrom:to:)`` and one
+    /// ``SwipeMenuViewDelegate/swipeMenuView(_:didChangeIndexFrom:to:)`` when the page actually
+    /// changes. An `index` with no corresponding page is ignored.
     /// - Parameters:
     ///   - index: The index of the page to display.
     ///   - animated: Whether the content transition is animated.
     public func jump(to index: Int, animated: Bool) {
         guard let tabView = tabView, let contentScrollView = contentScrollView else { return }
-        if currentIndex != index {
-            delegate?.swipeMenuView(self, willChangeIndexFrom: currentIndex, to: index)
-        }
-        jumpingToIndex = index
+        // Ignore indices that have no corresponding page rather than scrolling
+        // into empty space (or trapping on a negative index).
+        guard (0..<pageCount).contains(index) else { return }
 
+        let fromIndex = currentIndex
+
+        // The tab bar is repositioned immediately; only the content scroll honors `animated`.
         tabView.jump(to: index)
+
+        guard fromIndex != index else {
+            // Already on the target page; just keep the content offset aligned.
+            contentScrollView.jump(to: index, animated: animated)
+            return
+        }
+
+        delegate?.swipeMenuView(self, willChangeIndexFrom: fromIndex, to: index)
+
+        // While the programmatic scroll runs, `isJumping` suppresses the
+        // scroll-driven, one-page-at-a-time index updates in `scrollViewDidScroll(_:)`.
+        isJumping = true
+        jumpingToIndex = index
         contentScrollView.jump(to: index, animated: animated)
+
+        if !animated {
+            // A non-animated offset change fires no
+            // `scrollViewDidEndScrollingAnimation(_:)`, so finalize synchronously.
+            currentIndex = index
+            jumpingToIndex = nil
+            isJumping = false
+            delegate?.swipeMenuView(self, didChangeIndexFrom: fromIndex, to: index)
+        }
     }
 
     /// Notifies the view that an orientation change is about to occur so it can relayout.

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -125,6 +125,29 @@ struct SwipeMenuViewTests {
         ])
     }
 
+    @Test("Selecting a tab during an in-flight jump keeps delegate calls paired")
+    func tabSelectionDuringJumpKeepsDelegatePaired() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        let delegate = RecordingMenuDelegate()
+        view.delegate = delegate
+        defer { withExtendedLifetime((window, dataSource, delegate)) {} }
+
+        let tabView = try #require(view.tabView)
+
+        // Start an animated jump (in flight in this synchronous test), then tap a
+        // different tab before it completes. `finalizePendingJump()` runs
+        // synchronously at the start of the tab selection, so the first jump is
+        // paired deterministically regardless of the tap animation's timing.
+        view.jump(to: 2, animated: true)
+        view.tabView(tabView, didSelectTabAt: 3)
+
+        #expect(delegate.events.prefix(2) == [.willChange(from: 0, to: 2), .didChange(from: 0, to: 2)])
+    }
+
     @Test("jump(to:) ignores an out-of-range index")
     func jumpIgnoresOutOfRangeIndex() throws {
         let view = SwipeMenuView(frame: .zero)

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -97,6 +97,34 @@ struct SwipeMenuViewTests {
         #expect(delegate.events == [.willChange(from: 0, to: 2), .didChange(from: 0, to: 2)])
     }
 
+    @Test("A re-entrant jump keeps willChange/didChange calls paired")
+    func reentrantJumpKeepsDelegatePaired() {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        let delegate = RecordingMenuDelegate()
+        view.delegate = delegate
+        defer { withExtendedLifetime((window, dataSource, delegate)) {} }
+
+        // Start an animated jump (its end-of-animation callback does not fire in
+        // this synchronous test, so the jump stays "in flight"), then issue a
+        // second jump before the first completes.
+        view.jump(to: 2, animated: true)
+        view.jump(to: 0, animated: false)
+
+        // Each jump contributes exactly one paired willChange/didChange, and the
+        // view lands on the most recent target.
+        #expect(view.currentIndex == 0)
+        #expect(delegate.events == [
+            .willChange(from: 0, to: 2),
+            .didChange(from: 0, to: 2),
+            .willChange(from: 2, to: 0),
+            .didChange(from: 2, to: 0)
+        ])
+    }
+
     @Test("jump(to:) ignores an out-of-range index")
     func jumpIgnoresOutOfRangeIndex() throws {
         let view = SwipeMenuView(frame: .zero)

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -62,6 +62,61 @@ struct SwipeMenuViewTests {
         #expect(abs(contentScrollView.contentOffset.x - pageWidth * 2) < 0.5)
     }
 
+    @Test("jump(to:animated:false) updates currentIndex to the target page")
+    func jumpUpdatesCurrentIndex() {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // Jump across more than one page. The content offset and currentIndex
+        // must both land on the target.
+        view.jump(to: 3, animated: false)
+        #expect(view.currentIndex == 3)
+
+        view.jump(to: 1, animated: false)
+        #expect(view.currentIndex == 1)
+    }
+
+    @Test("jump(to:) emits one willChange/didChange pair to the target")
+    func jumpEmitsSingleDelegatePair() {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        // Attach the delegate after hosting so only the jump's events are recorded.
+        let delegate = RecordingMenuDelegate()
+        view.delegate = delegate
+        defer { withExtendedLifetime((window, dataSource, delegate)) {} }
+
+        view.jump(to: 2, animated: false)
+
+        #expect(delegate.events == [.willChange(from: 0, to: 2), .didChange(from: 0, to: 2)])
+    }
+
+    @Test("jump(to:) ignores an out-of-range index")
+    func jumpIgnoresOutOfRangeIndex() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let contentScrollView = try #require(view.contentScrollView)
+
+        view.jump(to: 99, animated: false)
+        #expect(view.currentIndex == 0)
+        #expect(abs(contentScrollView.contentOffset.x) < 0.5)
+
+        view.jump(to: -1, animated: false)
+        #expect(view.currentIndex == 0)
+        #expect(abs(contentScrollView.contentOffset.x) < 0.5)
+    }
+
     @Test("Delegate receives willSetup before didSetup")
     func delegateSetupOrdering() throws {
         let view = SwipeMenuView(frame: .zero)


### PR DESCRIPTION
## Summary

`SwipeMenuView.jump(to:animated:)` never set the internal `isJumping` flag, so the programmatic content-offset change it performs drove `scrollViewDidScroll(_:)`. That handler advances `currentIndex` **one page at a time**, so a jump across more than one page left the view's state inconsistent with what is actually on screen:

- `jump(to: 3, animated: false)` from page 0 ended with `currentIndex == 1` (content correctly at page 3).
- The delegate received a spurious extra pair, e.g. `willChange(0→2)`, `willChange(0→1)`, `didChange(0→1)` instead of a single `willChange(0→2)`, `didChange(0→2)`.
- An out-of-range index scrolled into empty space, and a **negative** index trapped in `TabView` (`itemViews[-1]`).

## Fix

- Guard the scroll callbacks with `isJumping` while the jump runs, mirroring the existing tab-tap path.
- Finalize `currentIndex`/`jumpingToIndex` and emit `didChange` synchronously for the non-animated case, which fires no `scrollViewDidEndScrollingAnimation(_:)`.
- Ignore indices outside `0..<numberOfPages` so `jump` is a safe no-op instead of scrolling off-screen or crashing.

After the change `jump(to:)` leaves `currentIndex` on the target and emits exactly one `willChange`/`didChange` pair when the page changes.

## Tests

Adds three tests to `SwipeMenuViewTests`:
- `currentIndex` lands on the target after a multi-page non-animated jump.
- The delegate receives exactly one `willChange`/`didChange` pair.
- An out-of-range (too large / negative) index is ignored without moving or crashing.

All 38 tests pass on the iOS simulator.