### PR TITLE
docs: link to the hosted DocC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange.svg?style=for-the-badge)](https://swift.org)
 [![SPM compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg?style=for-the-badge)](https://www.swift.org/documentation/package-manager/)
 [![CI](https://img.shields.io/github/actions/workflow/status/yysskk/SwipeMenuViewController/test.yml?branch=master&style=for-the-badge)](https://github.com/yysskk/SwipeMenuViewController/actions/workflows/test.yml)
+[![Documentation](https://img.shields.io/badge/documentation-DocC-blueviolet.svg?style=for-the-badge)](https://yysskk.github.io/SwipeMenuViewController/documentation/swipemenuviewcontroller/)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 ## Overview
@@ -68,7 +69,11 @@ By default each page is backed by one of the controller's `children`: the page c
 The delegate and data source callbacks are main-actor isolated, so implement them from your (main-actor) view controllers as usual.
 
 ## Documentation
-API documentation is available as a DocC catalog. Build it in Xcode with **Product ▸ Build Documentation**, then read the **Getting Started** and **Customizing Appearance** articles for the full setup walkthrough and every available option.
+The full API reference and articles are published online with DocC:
+
+**[Read the documentation →](https://yysskk.github.io/SwipeMenuViewController/documentation/swipemenuviewcontroller/)**
+
+Start with the **Getting Started** and **Customizing Appearance** articles for the full setup walkthrough and every available option. You can also build the documentation locally in Xcode with **Product ▸ Build Documentation**.
 
 ## Contributing
 Bug reports and pull requests are welcome. Please open an issue using one of the templates, and make sure the test suite passes (`xcodebuild test -scheme SwipeMenuViewController -destination 'platform=iOS Simulator,name=iPhone 16'`).


### PR DESCRIPTION
## Summary

Links the README to the DocC documentation that is now published on GitHub Pages (see #134).

- Adds a **Documentation** badge to the header, next to the existing badges.
- Rewrites the **Documentation** section to lead with a direct link to the hosted site, while keeping the note about building the docs locally in Xcode.

The documentation is hosted at:

```
https://yysskk.github.io/SwipeMenuViewController/documentation/swipemenuviewcontroller/
```

## Notes

- Documentation-only change; no source or public API is affected.
