### PR TITLE
Consolidate ContentScrollView page setup into a single pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed a potential crash in the default data source when `numberOfPages(in:)` returns more pages than there are child view controllers.
 - Fixed tab underline/text-color artifacts when swiping past the first or last tab.
 - Fixed `SwipeMenuView.jump(to:animated:)` leaving `currentIndex` and the delegate change callbacks out of sync with the content when jumping across more than one page, and made it ignore out-of-range indices (a negative index previously crashed).
+- Fixed `ContentScrollView` requesting nonexistent pages from its data source when built with an out-of-range initial index (for example `reloadData(default:)` past the last page).
 
 ## 4.1.0 - 2020-03-12
 - Added `circle` addition style with `cornerRadius` and `maskedCorners` options.

--- a/Sources/SwipeMenuViewController/ContentScrollView.swift
+++ b/Sources/SwipeMenuViewController/ContentScrollView.swift
@@ -86,7 +86,7 @@ open class ContentScrollView: UIScrollView {
 
     fileprivate func setup() {
 
-        guard let dataSource = dataSource else { return }
+        guard let dataSource else { return }
         if dataSource.numberOfPages(in: self) <= 0 { return }
 
         setupScrollView()
@@ -110,37 +110,27 @@ open class ContentScrollView: UIScrollView {
     private func setupPages() {
         pageViews = []
 
-        guard let dataSource = dataSource, dataSource.numberOfPages(in: self) > 0 else { return }
+        guard let dataSource else { return }
+        let pageCount = dataSource.numberOfPages(in: self)
+        guard pageCount > 0 else { return }
 
-        self.contentSize = CGSize(width: frame.width * CGFloat(dataSource.numberOfPages(in: self)), height: frame.height)
+        contentSize = CGSize(width: frame.width * CGFloat(pageCount), height: frame.height)
 
-        for i in 0...currentIndex {
-            guard let pageView = dataSource.contentScrollView(self, viewForPageAt: i) else { return }
+        // Build every page in order and pin each one after the previous, so an
+        // out-of-range `currentIndex` can never make us ask the data source for a
+        // page that does not exist.
+        for index in 0..<pageCount {
+            guard let pageView = dataSource.contentScrollView(self, viewForPageAt: index) else { return }
             pageViews.append(pageView)
             addSubview(pageView)
 
-            let leadingAnchor = i > 0 ? pageViews[i - 1].trailingAnchor : self.leadingAnchor
+            let leadingAnchor = index > 0 ? pageViews[index - 1].trailingAnchor : self.leadingAnchor
             pageView.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 pageView.topAnchor.constraint(equalTo: self.topAnchor),
                 pageView.widthAnchor.constraint(equalTo: self.widthAnchor),
                 pageView.heightAnchor.constraint(equalTo: self.heightAnchor),
                 pageView.leadingAnchor.constraint(equalTo: leadingAnchor)
-            ])
-        }
-
-        guard currentIndex < dataSource.numberOfPages(in: self) else { return }
-        for i in (currentIndex + 1)..<dataSource.numberOfPages(in: self) {
-            guard let pageView = dataSource.contentScrollView(self, viewForPageAt: i) else { return }
-            pageViews.append(pageView)
-            addSubview(pageView)
-
-            pageView.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                pageView.topAnchor.constraint(equalTo: self.topAnchor),
-                pageView.widthAnchor.constraint(equalTo: self.widthAnchor),
-                pageView.heightAnchor.constraint(equalTo: self.heightAnchor),
-                pageView.leadingAnchor.constraint(equalTo: pageViews[i - 1].trailingAnchor)
             ])
         }
     }

--- a/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
@@ -43,6 +43,22 @@ struct ContentScrollViewTests {
         #expect(abs(contentScrollView.contentOffset.x - pageWidth * 1) < 0.5)
     }
 
+    @Test("An out-of-range default index never asks for a nonexistent page")
+    func outOfRangeDefaultIndexDoesNotOverRead() {
+        // A default index past the last page must not make setup request pages
+        // that do not exist; it should still build exactly the real pages.
+        let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 10)
+        let dataSource = CountingContentDataSource(pageCount: 3)
+        contentScrollView.dataSource = dataSource
+
+        let window = hostInWindow(contentScrollView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(dataSource.requestedIndices.allSatisfy { (0..<3).contains($0) })
+        #expect(Set(dataSource.requestedIndices) == Set(0..<3))
+        #expect(abs(contentScrollView.contentSize.width - contentScrollView.frame.width * 3) < 0.5)
+    }
+
     @Test("A non-zero default index sets the matching current page")
     func nonZeroDefaultIndex() throws {
         let baseTag = 500

--- a/Tests/SwipeMenuViewControllerTests/TestSupport.swift
+++ b/Tests/SwipeMenuViewControllerTests/TestSupport.swift
@@ -107,6 +107,27 @@ final class StubContentDataSource: ContentScrollViewDataSource {
     }
 }
 
+/// A `ContentScrollViewDataSource` that records every page index it is asked
+/// for, so tests can assert that setup never over-reads past the last page.
+final class CountingContentDataSource: ContentScrollViewDataSource {
+
+    let pageCount: Int
+    private(set) var requestedIndices: [Int] = []
+
+    init(pageCount: Int) {
+        self.pageCount = pageCount
+    }
+
+    func numberOfPages(in contentScrollView: ContentScrollView) -> Int {
+        return pageCount
+    }
+
+    func contentScrollView(_ contentScrollView: ContentScrollView, viewForPageAt index: Int) -> UIView? {
+        requestedIndices.append(index)
+        return UIView()
+    }
+}
+
 // MARK: - Hosting helper
 
 /// Hosts `view` in a real window so that `didMoveToSuperview()` fires and layout


### PR DESCRIPTION
## Summary

`ContentScrollView.setupPages()` built its pages in two loops — `0...currentIndex` and then `currentIndex + 1..<pageCount` — with the `currentIndex < pageCount` guard placed only *before the second loop*.

When the view is created with an out-of-range initial index (for example `SwipeMenuView.reloadData(default:)` with an index past the last page), the first loop asks the data source for pages that do not exist. For a data source that indexes into a fixed collection (the common case, including the bundled example), that traps. Even for a lenient data source, it over-builds page views while `contentSize` is sized for the real page count.

Both loops did the same work, so this folds them into one `0..<pageCount` pass that pins each page after the previous. `currentIndex` no longer participates in page construction, so an out-of-range index can no longer over-read the data source.

Also adopts the Swift optional-binding shorthand (`guard let dataSource`) in the touched methods.

## Tests

Adds `CountingContentDataSource` (records every requested page index) and a test asserting that a `default: 10` content view over 3 pages requests only indices `0..<3`. The test fails on the previous implementation (it requested `0...10` and mis-sized the content) and passes now.

All 41 tests pass on the iOS simulator.