### PR TITLE
Expand unit test coverage

### DIFF
--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -221,4 +221,41 @@ struct SwipeMenuViewTests {
             #expect(contentScrollView.contentSize.width == 0)
         }
     }
+
+    @Test("reloadData(default:) shows the requested page")
+    func reloadDataWithDefaultIndex() throws {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        view.reloadData(default: 2)
+
+        #expect(view.currentIndex == 2)
+        let contentScrollView = try #require(view.contentScrollView)
+        #expect(abs(contentScrollView.contentOffset.x - contentScrollView.frame.width * 2) < 0.5)
+    }
+
+    @Test("An orientation relayout preserves the current index")
+    func orientationPreservesCurrentIndex() {
+        let view = SwipeMenuView(frame: .zero)
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C", "D"])
+        view.dataSource = dataSource
+
+        let window = hostInWindow(view)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        view.jump(to: 2, animated: false)
+        #expect(view.currentIndex == 2)
+
+        // Simulate an orientation change: willChangeOrientation() marks the next
+        // layout pass as a relayout that must not reset paging state.
+        view.willChangeOrientation()
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        #expect(view.currentIndex == 2)
+    }
 }

--- a/Tests/SwipeMenuViewControllerTests/TabItemViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabItemViewTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+@MainActor
+@Suite("TabItemView")
+struct TabItemViewTests {
+
+    @Test("isSelected switches the label between the text and selected colors")
+    func selectionTogglesLabelColor() {
+        let item = TabItemView(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
+        item.textColor = .gray
+        item.selectedTextColor = .red
+
+        item.isSelected = true
+        #expect(item.titleLabel.textColor == item.selectedTextColor)
+
+        item.isSelected = false
+        #expect(item.titleLabel.textColor == item.textColor)
+    }
+
+    @Test("The label is centered and hosted in the item view")
+    func labelIsConfigured() {
+        let item = TabItemView(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
+
+        #expect(item.titleLabel.textAlignment == .center)
+        #expect(item.titleLabel.superview === item)
+    }
+}

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -110,6 +110,20 @@ struct TabViewTests {
         #expect(additionViewCount(in: tabView) == 1)
     }
 
+    @Test("Circle addition produces an addition view in the hierarchy")
+    func circleAdditionExists() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.addition = .circle
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // The circle addition view is added to the container view hierarchy.
+        #expect(additionViewCount(in: tabView) == 1)
+    }
+
     @Test("No addition leaves the addition view out of the hierarchy")
     func noAdditionHasNoAdditionView() {
         var options = SwipeMenuViewOptions.TabView()
@@ -162,6 +176,33 @@ struct TabViewTests {
 
         let actual = lastItem.titleLabel.textColor ?? .clear
         #expect(colorsEqual(actual, expectedColor))
+    }
+
+    @Test("A forward swipe fades the current and next labels by the ratio")
+    func forwardSwipeInterpolatesNeighborColors() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.needsConvertTextColorRatio = true
+        // Use pure black/white endpoints so the midpoint is an unambiguous gray.
+        options.itemView.textColor = .black
+        options.itemView.selectedTextColor = .white
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        tabView.jump(to: 0)
+        // Halfway through a forward swipe from item 0 to item 1.
+        tabView.moveAdditionView(index: 0, ratio: 0.5, direction: .forward)
+
+        let midGray = UIColor(white: 0.5, alpha: 1)
+        let current = tabView.itemViews[0].titleLabel.textColor ?? .clear
+        let next = tabView.itemViews[1].titleLabel.textColor ?? .clear
+
+        // The current label fades selected -> text and the next fades text ->
+        // selected; at ratio 0.5 both meet in the middle.
+        #expect(colorsEqual(current, midGray))
+        #expect(colorsEqual(next, midGray))
     }
 
     /// Compares two colors by their RGBA components with a small tolerance.

--- a/Tests/SwipeMenuViewControllerTests/UIEdgeInsetsExtensionTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/UIEdgeInsetsExtensionTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import UIKit
+@testable import SwipeMenuViewController
+
+@MainActor
+@Suite("UIEdgeInsets extension")
+struct UIEdgeInsetsExtensionTests {
+
+    @Test("init(horizontal:vertical:) mirrors each value onto both edges")
+    func symmetricInit() {
+        let insets = UIEdgeInsets(horizontal: 8, vertical: 4)
+
+        #expect(insets.left == 8)
+        #expect(insets.right == 8)
+        #expect(insets.top == 4)
+        #expect(insets.bottom == 4)
+    }
+
+    @Test("horizontal and vertical sum their paired edges")
+    func pairedSums() {
+        let insets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+
+        #expect(insets.horizontal == 6)   // left + right
+        #expect(insets.vertical == 4)     // top + bottom
+    }
+
+    @Test("zero insets have zero sums")
+    func zeroInsets() {
+        let insets = UIEdgeInsets.zero
+
+        #expect(insets.horizontal == 0)
+        #expect(insets.vertical == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds tests for behavior that was previously uncovered by the suite. No production code changes.

- **`UIEdgeInsets` extension** — the `init(horizontal:vertical:)` convenience initializer and the `horizontal` / `vertical` sum helpers.
- **`TabItemView`** — `isSelected` switching the label between the text and selected colors, and basic label setup (centered, hosted).
- **Circle addition style** — building an addition view in the container hierarchy (the underline and `.none` styles were already covered; `.circle` was not).
- **Forward-swipe color interpolation** — the current/next label fade math at a mid-swipe ratio (previously only the past-the-last-tab boundary case was covered).
- **`SwipeMenuView.reloadData(default:)`** — landing on the requested page.
- **Orientation relayout** — `willChangeOrientation()` followed by a layout pass preserving `currentIndex`.

## Notes

Two new stubs-free test files (`UIEdgeInsetsExtensionTests`, `TabItemViewTests`) plus additions to the existing `TabView` and `SwipeMenuView` suites. The suite goes from 41 to 50 tests; all pass on the iOS simulator.