### PR TITLE
Rebuild the paging views only while attached to a superview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed tab underline/text-color artifacts when swiping past the first or last tab.
 - Fixed `SwipeMenuView.jump(to:animated:)` leaving `currentIndex` and the delegate change callbacks out of sync with the content when jumping across more than one page, and made it ignore out-of-range indices (a negative index previously crashed).
 - Fixed `ContentScrollView` requesting nonexistent pages from its data source when built with an out-of-range initial index (for example `reloadData(default:)` past the last page).
+- Fixed the views rebuilding themselves when removed from their superview (emitting spurious delegate setup callbacks) and duplicating their tab and content subviews when a `SwipeMenuView` was removed and re-added to a view hierarchy.
 
 ## 4.1.0 - 2020-03-12
 - Added `circle` addition style with `cornerRadius` and `maskedCorners` options.

--- a/Sources/SwipeMenuViewController/ContentScrollView.swift
+++ b/Sources/SwipeMenuViewController/ContentScrollView.swift
@@ -56,6 +56,9 @@ open class ContentScrollView: UIScrollView {
     }
 
     open override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        // Skip the rebuild when the view is being removed (superview is nil).
+        guard superview != nil else { return }
         setup()
     }
 

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -305,6 +305,17 @@ open class SwipeMenuView: UIView {
     open override func didMoveToSuperview() {
         super.didMoveToSuperview()
 
+        // `didMoveToSuperview()` also fires when the view is removed (superview
+        // becomes nil); rebuilding then would emit spurious delegate setup
+        // callbacks and leave stale subviews behind.
+        guard superview != nil else { return }
+
+        // If the view is being re-added after a previous setup, tear the old tab
+        // and content views down first so they are not duplicated.
+        if tabView != nil {
+            reset()
+        }
+
         setup()
     }
 

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -87,6 +87,9 @@ open class TabView: UIScrollView {
     }
 
     open override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        // Skip the rebuild when the view is being removed (superview is nil).
+        guard superview != nil else { return }
         reloadData()
     }
 

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewTests.swift
@@ -258,4 +258,48 @@ struct SwipeMenuViewTests {
 
         #expect(view.currentIndex == 2)
     }
+
+    @Test("Removing and re-adding the view does not duplicate its subviews")
+    func reAddDoesNotDuplicateSubviews() {
+        let view = SwipeMenuView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window1 = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        window1.addSubview(view)
+        view.layoutIfNeeded()
+
+        view.removeFromSuperview()
+
+        let window2 = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        window2.addSubview(view)
+        view.layoutIfNeeded()
+        defer { withExtendedLifetime((window1, window2, dataSource)) {} }
+
+        // Exactly one tab view and one content view, not one per attach.
+        #expect(view.subviews.compactMap { $0 as? TabView }.count == 1)
+        #expect(view.subviews.compactMap { $0 as? ContentScrollView }.count == 1)
+        #expect(view.tabView?.itemViews.count == 3)
+    }
+
+    @Test("Removal does not emit setup callbacks")
+    func removalDoesNotEmitSetupCallbacks() {
+        let view = SwipeMenuView(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        let dataSource = StubMenuDataSource(titles: ["A", "B", "C"])
+        view.dataSource = dataSource
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        window.addSubview(view)
+        view.layoutIfNeeded()
+
+        // Attach the delegate after the initial setup so only removal is observed.
+        let delegate = RecordingMenuDelegate()
+        view.delegate = delegate
+        defer { withExtendedLifetime((window, dataSource, delegate)) {} }
+
+        view.removeFromSuperview()
+
+        // Removal must not run setup again.
+        #expect(delegate.events.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

`didMoveToSuperview()` fires on **both** attach and detach (on detach, `superview` is `nil`). `SwipeMenuView`, `TabView`, and `ContentScrollView` all rebuilt themselves in that callback unconditionally, which caused two problems:

1. **Spurious work/callbacks on removal** — removing a `SwipeMenuView` re-ran `setup()`, firing `viewWillSetupAt` / `viewDidSetupAt` on the delegate even though the view was being torn down.
2. **Duplicate subviews on re-add** — because `setup()` creates a fresh `tabView`/`contentScrollView` and adds them as subviews without removing the previous ones, removing and re-adding a `SwipeMenuView` (e.g. moving it between containers) accumulated a new tab bar and content view on every attach.

## Fix

- Guard each `didMoveToSuperview()` on a non-nil `superview` so nothing rebuilds on removal (and add the missing `super` calls).
- When a `SwipeMenuView` is re-added after a previous setup, `reset()` the existing tab/content views before rebuilding.

## Tests

- `reAddDoesNotDuplicateSubviews` — attach, detach, re-attach leaves exactly one `TabView` and one `ContentScrollView`. Fails on the previous code (three of each).
- `removalDoesNotEmitSetupCallbacks` — removal emits no delegate setup callbacks. Fails on the previous code (`willSetup`/`didSetup` were delivered).

All 52 tests pass on the iOS simulator.