### PR TITLE
Respect isSafeAreaEnabled in TabView.safeAreaInsetsDidChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed `SwipeMenuView.jump(to:animated:)` leaving `currentIndex` and the delegate change callbacks out of sync with the content when jumping across more than one page, and made it ignore out-of-range indices (a negative index previously crashed).
 - Fixed `ContentScrollView` requesting nonexistent pages from its data source when built with an out-of-range initial index (for example `reloadData(default:)` past the last page).
 - Fixed the views rebuilding themselves when removed from their superview (emitting spurious delegate setup callbacks) and duplicating their tab and content subviews when a `SwipeMenuView` was removed and re-added to a view hierarchy.
+- Fixed the tab bar applying safe-area insets even when `isSafeAreaEnabled` is `false`, so a safe-area change (rotation, notch) no longer shifts a tab bar that opted out of safe-area layout.
 
 ## 4.1.0 - 2020-03-12
 - Added `circle` addition style with `cornerRadius` and `maskedCorners` options.

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -101,6 +101,12 @@ open class TabView: UIScrollView {
     open override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
 
+        // Respect `isSafeAreaEnabled`: when safe-area layout is turned off, a
+        // safe-area change (rotation, a notch coming into play) must not shift
+        // the tab bar by the inset. The initial layout already positioned the
+        // container without the inset, so leave the constraints untouched.
+        guard options.isSafeAreaEnabled else { return }
+
         leftMarginConstraint.constant = options.margin + safeAreaInsets.left
         if options.style == .segmented {
             widthConstraint.constant = options.margin * -2 - safeAreaInsets.left - safeAreaInsets.right

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -85,6 +85,53 @@ struct TabViewTests {
         #expect(abs(total - tabView.frame.width) < 1.0)
     }
 
+    @Test("With safe area disabled, a safe-area change does not shrink segmented items")
+    func safeAreaDisabledIgnoresInsetChanges() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .segmented
+        options.margin = 0
+        options.isSafeAreaEnabled = false
+
+        let dataSource = StubTabViewDataSource(titles: ["A", "B", "C", "D"])
+        let tabView = TabView(frame: CGRect(x: 0, y: 0, width: 400, height: options.height), options: options)
+        tabView.dataSource = dataSource
+
+        // Host inside a view controller so its safe area can be driven via
+        // additionalSafeAreaInsets (a UIViewController-only property).
+        let viewController = UIViewController()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 667))
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        tabView.translatesAutoresizingMaskIntoConstraints = false
+        viewController.view.addSubview(tabView)
+        NSLayoutConstraint.activate([
+            tabView.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            tabView.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+            tabView.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+            tabView.heightAnchor.constraint(equalToConstant: options.height)
+        ])
+        viewController.view.layoutIfNeeded()
+        // Build the items against the stable frame with no safe area yet.
+        tabView.reloadData()
+        viewController.view.layoutIfNeeded()
+
+        // Now introduce a safe area. This fires safeAreaInsetsDidChange() on the
+        // tab view; with safe area disabled it must not resize the items.
+        viewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+
+        // Precondition: the safe area really reached the tab view, so the
+        // assertion below is meaningful rather than a silent no-op.
+        #expect(tabView.safeAreaInsets.left == 20)
+
+        let total = tabView.itemViews.reduce(0) { $0 + $1.frame.width }
+        // Items still span the full tab width, not width - (left + right).
+        #expect(abs(total - tabView.frame.width) < 1.0)
+    }
+
     /// Counts the plain (non-`TabItemView`) `UIView` subviews inside the tab's
     /// container stack view. The underline/circle addition view is added there
     /// as a plain `UIView`; the item views are `TabItemView`s. `additionView`


### PR DESCRIPTION
## Summary

`TabView.safeAreaInsetsDidChange()` updated the container's leading-margin and width constraints from `safeAreaInsets` **unconditionally**, ignoring the `isSafeAreaEnabled` option that the rest of the layout honors.

As a result, a tab bar configured with `isSafeAreaEnabled == false` was still shifted (and, for the segmented style, narrowed) by the safe-area inset whenever the safe area changed — the first time it appears on a notched device, or on rotation — undoing the opt-out that the initial layout had applied.

## Fix

Return early from `safeAreaInsetsDidChange()` when `isSafeAreaEnabled` is `false`, leaving the inset-free constraints from the initial layout in place. When safe-area layout is enabled (the default) the behavior is unchanged.

## Tests

Adds `safeAreaDisabledIgnoresInsetChanges`: hosts a segmented tab bar with `isSafeAreaEnabled == false` in a view controller, introduces a safe area via `additionalSafeAreaInsets`, and asserts the item widths still span the full tab width. A precondition check (`safeAreaInsets.left == 20`) guarantees the safe area actually reached the tab view. The test fails on the previous code (items shrank by the inset) and passes now.

All 53 tests pass on the iOS simulator.