### PR TITLE
Document direct SwipeMenuView usage and reload() requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,49 @@ final class MenuViewController: SwipeMenuViewController {
 }
 ```
 
-By default each page is backed by one of the controller's `children`: the page count is `children.count`, each tab title is the child's `title`, and each page shows the child's view. Override the `SwipeMenuViewDataSource` methods for fully custom paging, or embed a `SwipeMenuView` directly when you want the paging UI inside an existing view hierarchy.
+By default each page is backed by one of the controller's `children`: the page count is `children.count`, each tab title is the child's `title`, and each page shows the child's view. Override the `SwipeMenuViewDataSource` methods for fully custom paging.
 
-The delegate and data source callbacks are main-actor isolated, so implement them from your (main-actor) view controllers as usual.
+To place the paging UI inside a view hierarchy you already have, add a `SwipeMenuView` directly, set its `dataSource` (and optional `delegate`), and customize it with `SwipeMenuViewOptions`:
+
+```swift
+import SwipeMenuViewController
+
+final class CatalogViewController: UIViewController {
+
+    private let swipeMenuView = SwipeMenuView(frame: .zero)
+    private let titles = ["Sports", "News", "Weather"]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        swipeMenuView.frame = view.bounds
+        swipeMenuView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        swipeMenuView.dataSource = self
+        view.addSubview(swipeMenuView)
+
+        var options = SwipeMenuViewOptions()
+        options.tabView.style = .segmented
+        swipeMenuView.reloadData(options: options)
+    }
+}
+
+extension CatalogViewController: SwipeMenuViewDataSource {
+
+    func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int { titles.count }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String {
+        titles[index]
+    }
+
+    func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewControllerForPageAt index: Int) -> UIViewController {
+        let page = UIViewController()
+        page.title = titles[index]
+        return page
+    }
+}
+```
+
+The delegate and data source callbacks are main-actor isolated, so implement them from your (main-actor) view controllers as usual. See the [documentation](#documentation) for every `SwipeMenuViewOptions` field.
 
 ## Documentation
 The full API reference and articles are published online with DocC:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ final class MenuViewController: SwipeMenuViewController {
 
 By default each page is backed by one of the controller's `children`: the page count is `children.count`, each tab title is the child's `title`, and each page shows the child's view. Override the `SwipeMenuViewDataSource` methods for fully custom paging.
 
-To place the paging UI inside a view hierarchy you already have, add a `SwipeMenuView` directly, set its `dataSource` (and optional `delegate`), and customize it with `SwipeMenuViewOptions`:
+To place the paging UI inside a view hierarchy you already have, add a `SwipeMenuView` directly, set its `dataSource` (and optional `delegate`), and customize it with `SwipeMenuViewOptions`.
+
+`SwipeMenuView` is a plain `UIView`, so it only reads each page's `view` — it cannot establish view-controller containment for you. When your pages are view controllers, add them as children yourself so they receive the usual appearance and trait-collection callbacks:
 
 ```swift
 import SwipeMenuViewController
@@ -74,10 +76,18 @@ import SwipeMenuViewController
 final class CatalogViewController: UIViewController {
 
     private let swipeMenuView = SwipeMenuView(frame: .zero)
-    private let titles = ["Sports", "News", "Weather"]
+
+    private let pages: [UIViewController] = ["Sports", "News", "Weather"].map { title in
+        let page = UIViewController()
+        page.title = title
+        return page
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Establish containment: the host view controller owns the pages.
+        pages.forEach { addChild($0) }
 
         swipeMenuView.frame = view.bounds
         swipeMenuView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -87,21 +97,22 @@ final class CatalogViewController: UIViewController {
         var options = SwipeMenuViewOptions()
         options.tabView.style = .segmented
         swipeMenuView.reloadData(options: options)
+
+        // reloadData added each page's view, so finish containment.
+        pages.forEach { $0.didMove(toParent: self) }
     }
 }
 
 extension CatalogViewController: SwipeMenuViewDataSource {
 
-    func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int { titles.count }
+    func numberOfPages(in swipeMenuView: SwipeMenuView) -> Int { pages.count }
 
     func swipeMenuView(_ swipeMenuView: SwipeMenuView, titleForPageAt index: Int) -> String {
-        titles[index]
+        pages[index].title ?? ""
     }
 
     func swipeMenuView(_ swipeMenuView: SwipeMenuView, viewControllerForPageAt index: Int) -> UIViewController {
-        let page = UIViewController()
-        page.title = titles[index]
-        return page
+        pages[index]
     }
 }
 ```

--- a/Sources/SwipeMenuViewController/ContentScrollView.swift
+++ b/Sources/SwipeMenuViewController/ContentScrollView.swift
@@ -75,8 +75,11 @@ open class ContentScrollView: UIScrollView {
     }
 
     /// Rebuilds the page views from the data source.
+    ///
+    /// The view must already be in a view hierarchy; when it has no superview
+    /// this method does nothing.
     public func reload() {
-        self.didMoveToSuperview()
+        didMoveToSuperview()
     }
 
     /// Updates the tracked current page index without changing the scroll offset.


### PR DESCRIPTION
## Summary

Documentation-only changes to smooth adoption:

- **README** — add a worked example of embedding a `SwipeMenuView` directly in an existing view hierarchy (assign `dataSource`, configure `SwipeMenuViewOptions`, conform to `SwipeMenuViewDataSource`). Until now the README only showed the `SwipeMenuViewController` subclass path, even though it mentioned embedding a view directly.
- **`ContentScrollView.reload()`** — document that it requires the view to already be in a view hierarchy (it forwards to `didMoveToSuperview()`, which no-ops when the view has no superview).

No behavior or API changes.