### PR TITLE
Adopt the shorthand optional-binding syntax

### DIFF
--- a/Sources/SwipeMenuViewController/ContentScrollView.swift
+++ b/Sources/SwipeMenuViewController/ContentScrollView.swift
@@ -46,7 +46,7 @@ open class ContentScrollView: UIScrollView {
 
         self.contentInsetAdjustmentBehavior = .never
 
-        if let options = options {
+        if let options {
             self.options = options
         }
     }

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -236,7 +236,7 @@ open class SwipeMenuView: UIView {
     /// The tab bar displayed above the content, or `nil` before the view is set up.
     open fileprivate(set) var tabView: TabView? {
         didSet {
-            guard let tabView = tabView else { return }
+            guard let tabView else { return }
             tabView.dataSource = self
             tabView.tabViewDelegate = self
             addSubview(tabView)
@@ -247,7 +247,7 @@ open class SwipeMenuView: UIView {
     /// The horizontally paging scroll view that hosts the page views, or `nil` before the view is set up.
     open fileprivate(set) var contentScrollView: ContentScrollView? {
         didSet {
-            guard let contentScrollView = contentScrollView else { return }
+            guard let contentScrollView else { return }
             contentScrollView.delegate = self
             contentScrollView.dataSource = self
             addSubview(contentScrollView)
@@ -277,7 +277,7 @@ open class SwipeMenuView: UIView {
     ///   - options: The appearance and behavior options. Pass `nil` to use the defaults.
     public init(frame: CGRect, options: SwipeMenuViewOptions? = nil) {
 
-        if let options = options {
+        if let options {
             self.options = options
         } else {
             self.options = .init()
@@ -327,7 +327,7 @@ open class SwipeMenuView: UIView {
     ///     view relayouts without resetting its state. Defaults to `false`.
     public func reloadData(options: SwipeMenuViewOptions? = nil, default defaultIndex: Int? = nil, isOrientationChange: Bool = false) {
 
-        if let options = options {
+        if let options {
             self.options = options
         }
 
@@ -485,7 +485,7 @@ open class SwipeMenuView: UIView {
             currentIndex = 0
         }
 
-        if let tabView = tabView, let contentScrollView = contentScrollView {
+        if let tabView, let contentScrollView {
             tabView.removeFromSuperview()
             contentScrollView.removeFromSuperview()
             tabView.reset()
@@ -568,7 +568,7 @@ extension SwipeMenuView: UIScrollViewDelegate {
     /// update underbar position
     private func moveAdditionView(scrollView: UIScrollView) {
 
-        if let tabView = tabView, let contentScrollView = contentScrollView {
+        if let tabView, let contentScrollView {
 
             let ratio = scrollView.contentOffset.x.truncatingRemainder(dividingBy: contentScrollView.frame.width) / contentScrollView.frame.width
 

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -77,7 +77,7 @@ open class TabView: UIScrollView {
     public init(frame: CGRect, options: SwipeMenuViewOptions.TabView? = nil) {
         super.init(frame: frame)
 
-        if let options = options {
+        if let options {
             self.options = options
         }
     }
@@ -150,13 +150,13 @@ open class TabView: UIScrollView {
                            default defaultIndex: Int? = nil,
                            animated: Bool = true) {
 
-        if let options = options {
+        if let options {
             self.options = options
         }
 
         reset()
 
-        guard let dataSource = dataSource,
+        guard let dataSource,
             dataSource.numberOfItems(in: self) > 0 else { return }
 
         setupScrollView()
@@ -164,7 +164,7 @@ open class TabView: UIScrollView {
         setupTabItemViews(dataSource: dataSource)
         setupAdditionView()
 
-        if let defaultIndex = defaultIndex {
+        if let defaultIndex {
             moveTabItem(index: defaultIndex, animated: animated)
         }
     }
@@ -463,12 +463,12 @@ extension TabView {
 
         update(index)
 
-        guard let currentItem = currentItem else { return }
+        guard let currentItem else { return }
 
         if options.additionView.isAnimationOnSwipeEnable {
             switch direction {
             case .forward:
-                if let nextItem = nextItem {
+                if let nextItem {
                     additionView.frame.origin.x = currentItem.frame.origin.x + (nextItem.frame.origin.x - currentItem.frame.origin.x) * ratio + options.additionView.padding.left
                     additionView.frame.size.width = currentItem.frame.size.width + (nextItem.frame.size.width - currentItem.frame.size.width) * ratio - options.additionView.padding.horizontal
                     if options.needsConvertTextColorRatio {
@@ -477,7 +477,7 @@ extension TabView {
                     }
                 }
             case .reverse:
-                if let previousItem = previousItem {
+                if let previousItem {
                     additionView.frame.origin.x = previousItem.frame.origin.x + (currentItem.frame.origin.x - previousItem.frame.origin.x) * ratio + options.additionView.padding.left
                     additionView.frame.size.width = previousItem.frame.size.width + (currentItem.frame.size.width - previousItem.frame.size.width) * ratio - options.additionView.padding.horizontal
                     if options.needsConvertTextColorRatio {
@@ -516,7 +516,7 @@ extension TabView {
     func jump(to index: Int) {
         update(index)
 
-        guard let currentItem = currentItem else { return }
+        guard let currentItem else { return }
 
         if options.addition == .underline {
             additionView.frame.origin.x = currentItem.frame.origin.x + options.additionView.padding.left


### PR DESCRIPTION
## Summary

Modernize the redundant same-name optional bindings to the Swift 5.7+ shorthand across the sources:

- `guard let x = x { … }` → `guard let x { … }`
- `if let x = x { … }` → `if let x { … }`

This covers the bindings in `SwipeMenuView`, `TabView`, and `ContentScrollView` (view/data-source unwraps, `options`/`defaultIndex` in the initializers and `reloadData`, and the `currentItem`/`nextItem`/`previousItem` unwraps).

Only same-name bindings were rewritten; renaming bindings (`let y = x`) are left as-is. No behavior change — purely a readability/idiom cleanup.

All 53 tests pass on the iOS simulator.