### PR TITLE
Prepare 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.0.0 (Unreleased)
+## 5.0.0 - 2026-07-05
 
 ### Breaking
 - Distribution is Swift Package Manager only. CocoaPods and Carthage support has been removed (the podspec and the framework Xcode project were deleted).


### PR DESCRIPTION
## Summary

Finalizes the changelog for the 5.0.0 release by dating the section heading. No code changes.

## Testing

Documentation-only. The full test suite, example app, and documentation build remain green on master.