### PR TITLE
Add numberOfLines option for multi-line tab titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `SwipeMenuViewOptions.TabView.ItemView.numberOfLines` to let tab titles wrap onto multiple lines (use `0` for as many lines as the title needs). Defaults to `1`, preserving the previous single-line behavior. Most useful with the `.segmented` style, where a long title would otherwise be truncated.
+
 ## 5.0.0 - 2026-07-05
 
 ### Breaking

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -35,6 +35,13 @@ public nonisolated struct SwipeMenuViewOptions: Sendable {
 
             /// ItemView selected textColor. Defaults to `.black`.
             public var selectedTextColor: UIColor = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)
+
+            /// The maximum number of lines used to render the title. Use `0` to allow as many lines
+            /// as the title needs. Titles that do not fit are truncated. Defaults to `1`.
+            ///
+            /// This is most useful with the `.segmented` style, where each item has a fixed width and
+            /// a long title would otherwise be truncated onto a single line.
+            public var numberOfLines: Int = 1
         }
 
         public nonisolated struct AdditionView: Sendable {

--- a/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
+++ b/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
@@ -60,6 +60,7 @@ The `itemView` group configures each individual tab:
 - `clipsToBounds`: whether the item clips its contents. Defaults to `true`.
 - `textColor`: the title color when unselected. Defaults to a gray.
 - `selectedTextColor`: the title color when selected. Defaults to black.
+- `numberOfLines`: the maximum number of lines for the title. Use `0` to allow as many lines as the title needs. Defaults to `1`.
 
 ```swift
 options.tabView.itemView.width = 120
@@ -67,6 +68,15 @@ options.tabView.itemView.margin = 8
 options.tabView.itemView.font = .boldSystemFont(ofSize: 15)
 options.tabView.itemView.textColor = .secondaryLabel
 options.tabView.itemView.selectedTextColor = .label
+options.tabView.itemView.numberOfLines = 2
+```
+
+Multi-line titles are most useful with the `.segmented` style, where every item has a fixed width and
+a long title would otherwise be truncated onto a single line:
+
+```swift
+options.tabView.style = .segmented
+options.tabView.itemView.numberOfLines = 0
 ```
 
 ## Selection indicator

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -257,6 +257,7 @@ open class TabView: UIScrollView {
             if let title = dataSource.tabView(self, titleForItemAt: index) {
                 tabItemView.titleLabel.text = title
                 tabItemView.titleLabel.font = options.itemView.font
+                tabItemView.titleLabel.numberOfLines = options.itemView.numberOfLines
                 tabItemView.textColor = options.itemView.textColor
                 tabItemView.selectedTextColor = options.itemView.selectedTextColor
             }

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -33,6 +33,7 @@ struct SwipeMenuViewOptionsTests {
         #expect(options.tabView.itemView.margin == 5.0)
         #expect(options.tabView.itemView.font == UIFont.boldSystemFont(ofSize: 14))
         #expect(options.tabView.itemView.clipsToBounds == true)
+        #expect(options.tabView.itemView.numberOfLines == 1)
     }
 
     @Test("AdditionView documented defaults")

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -42,6 +42,33 @@ struct TabViewTests {
         #expect(tabView.itemViews.dropFirst().allSatisfy { $0.isSelected == false })
     }
 
+    // MARK: - Item title lines
+
+    @Test("By default each title label is limited to a single line")
+    func titleLabelsAreSingleLineByDefault() {
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: SwipeMenuViewOptions.TabView())
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.allSatisfy { $0.titleLabel.numberOfLines == 1 })
+    }
+
+    @Test("itemView.numberOfLines is applied to every title label")
+    func numberOfLinesIsApplied() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .segmented
+        // `0` means the label uses as many lines as the title needs.
+        options.itemView.numberOfLines = 0
+
+        let (tabView, dataSource) = makeTabView(titles: ["Long title one", "Long title two"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        #expect(tabView.itemViews.allSatisfy { $0.titleLabel.numberOfLines == 0 })
+    }
+
     @Test("Flexible style with fixed width uses options.itemView.width")
     func flexibleFixedWidth() {
         var options = SwipeMenuViewOptions.TabView()


### PR DESCRIPTION
## Summary

Tab titles are always rendered on a single line, so a title longer than its item width is truncated. This adds a `numberOfLines` option to the tab item so titles can wrap onto multiple lines.

- New `SwipeMenuViewOptions.TabView.ItemView.numberOfLines`, applied to each tab item's title label.
- Defaults to `1`, preserving the current single-line behavior. Use `0` for as many lines as the title needs.
- Most useful with the `.segmented` style, where items have a fixed width and a long title would otherwise be truncated onto one line.

Adapts the proposal from #123 to the current Swift package layout.

## Usage

```swift
var options = SwipeMenuViewOptions()
options.tabView.style = .segmented
options.tabView.itemView.numberOfLines = 0
swipeMenuView.reloadData(options: options)
```

## Tests

- Documented default of `numberOfLines` is `1`.
- Every tab item's title label reflects `itemView.numberOfLines`, for both the default and a custom value.
- The full Swift Testing suite passes on the iOS simulator, and DocC builds with `--warnings-as-errors`.