### PR TITLE
Reference the main branch in CI and documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@ name: Documentation
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 # Allow only one concurrent deployment. Do not cancel in-progress runs, so that

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,13 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
   workflow_dispatch:
 
 concurrency:
   group: test-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   package:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Platform](https://img.shields.io/badge/platform-iOS-blue.svg?style=for-the-badge)](https://developer.apple.com/ios/)
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange.svg?style=for-the-badge)](https://swift.org)
 [![SPM compatible](https://img.shields.io/badge/SPM-compatible-brightgreen.svg?style=for-the-badge)](https://www.swift.org/documentation/package-manager/)
-[![CI](https://img.shields.io/github/actions/workflow/status/yysskk/SwipeMenuViewController/test.yml?branch=master&style=for-the-badge)](https://github.com/yysskk/SwipeMenuViewController/actions/workflows/test.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/yysskk/SwipeMenuViewController/test.yml?branch=main&style=for-the-badge)](https://github.com/yysskk/SwipeMenuViewController/actions/workflows/test.yml)
 [![Documentation](https://img.shields.io/badge/documentation-DocC-blueviolet.svg?style=for-the-badge)](https://yysskk.github.io/SwipeMenuViewController/documentation/swipemenuviewcontroller/)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary

Prepare CI and documentation for renaming the repository's default branch from `master` to `main`. This lands **before** the rename so that pull requests targeting `main` keep producing their required status checks.

## Changes

- **Test workflow**: push trigger `master` → `main`; the `pull_request` trigger no longer filters by base branch, so it runs on PRs regardless of the default branch name (this makes the rename seamless — no gap in the `Package tests` / `Example app build` required checks). Concurrency's default-branch guard updated to `main`.
- **Documentation workflow**: push trigger `master` → `main`.
- **README**: CI badge now queries the `main` branch. (The demo-GIF URLs point at the separate `yysskk/Assets` repository and are intentionally left as-is.)

## Follow-up

After this merges, the default branch is renamed `master` → `main` via GitHub (which moves branch protection and retargets open PRs automatically).
