### PR TITLE
Fix segmented tab indicator offset at the first tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - `SwipeMenuViewOptions.TabView.ItemView.numberOfLines` to let tab titles wrap onto multiple lines (use `0` for as many lines as the title needs). Defaults to `1`, preserving the previous single-line behavior. Most useful with the `.segmented` style, where a long title would otherwise be truncated.
 
+### Fixed
+- The `.segmented` tab style mispositioned the selection indicator when `additionView.padding` had non-zero horizontal insets: the first tab's indicator spilled off the leading edge, and each later tab drifted increasingly to the left. The indicator now aligns with every tab, inset by the padding, consistent with the other tab styles (issue #25).
+
 ## 5.0.0 - 2026-07-05
 
 ### Breaking

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -434,17 +434,22 @@ extension TabView {
 
     fileprivate func resetAdditionViewPosition(index: Int) {
         guard options.style == .segmented,
-            let dataSource = dataSource,
+            let dataSource,
             dataSource.numberOfItems(in: self) > 0 else { return }
-        let adjustCellWidth: CGFloat
+
+        // Each `.segmented` tab item spans the full (unadjusted) cell width, so
+        // that width is the indicator's per-tab stride. The indicator itself is
+        // inset by the horizontal padding. Using the padding-adjusted width as the
+        // stride would drift the indicator left by `index * padding.horizontal`.
+        let cellWidth: CGFloat
         if options.isSafeAreaEnabled && safeAreaInsets != .zero {
-            adjustCellWidth = (frame.width - options.margin * 2 - safeAreaInsets.left - safeAreaInsets.right) / CGFloat(dataSource.numberOfItems(in: self)) - options.additionView.padding.horizontal
+            cellWidth = (frame.width - options.margin * 2 - safeAreaInsets.left - safeAreaInsets.right) / CGFloat(dataSource.numberOfItems(in: self))
         } else {
-            adjustCellWidth = (frame.width - options.margin * 2) / CGFloat(dataSource.numberOfItems(in: self)) - options.additionView.padding.horizontal
+            cellWidth = (frame.width - options.margin * 2) / CGFloat(dataSource.numberOfItems(in: self))
         }
 
-        additionView.frame.origin.x = adjustCellWidth * CGFloat(index) - options.additionView.padding.left
-        additionView.frame.size.width = adjustCellWidth
+        additionView.frame.origin.x = cellWidth * CGFloat(index) + options.additionView.padding.left
+        additionView.frame.size.width = cellWidth - options.additionView.padding.horizontal
     }
 
     fileprivate func animateAdditionView(index: Int, animated: Bool, completion: ((Bool) -> Swift.Void)? = nil) {

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -170,6 +170,16 @@ struct TabViewTests {
         return container.subviews.filter { type(of: $0) == UIView.self }.count
     }
 
+    /// Returns the plain (non-`TabItemView`) `UIView` acting as the selection
+    /// indicator inside the container stack view, or `nil` if there is none.
+    /// `additionView` is `fileprivate`, so it is located through the hierarchy.
+    private func additionView(in tabView: TabView) -> UIView? {
+        guard let container = tabView.subviews.first(where: { $0 is UIStackView }) else {
+            return nil
+        }
+        return container.subviews.first { type(of: $0) == UIView.self }
+    }
+
     @Test("Underline addition produces an addition view in the hierarchy")
     func underlineAdditionExists() {
         var options = SwipeMenuViewOptions.TabView()
@@ -210,6 +220,43 @@ struct TabViewTests {
 
         // With `.none`, the addition view is never added to the container.
         #expect(additionViewCount(in: tabView) == 0)
+    }
+
+    // MARK: - Segmented indicator offset (issue #25)
+
+    @Test("Segmented indicator sits inside every tab, inset by the padding")
+    func segmentedIndicatorAlignsWithEachTab() throws {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .segmented
+        options.addition = .underline
+        options.margin = 0
+        // Non-zero horizontal padding makes both the offset sign (first tab) and
+        // the per-tab stride (later tabs) observable.
+        options.additionView.padding = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+
+        let titles = ["A", "B", "C"]
+        let (tabView, dataSource) = makeTabView(titles: titles, options: options)
+
+        let window = hostTabView(tabView, width: 375)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let indicator = try #require(additionView(in: tabView))
+        let padding = options.additionView.padding
+
+        // The indicator should align with the selected tab's frame, inset by the
+        // padding — the same way the flexible style aligns it. Before the fix the
+        // segmented path placed the first tab at `-padding.left` and used the
+        // padding-adjusted width as the per-tab stride, so later tabs drifted left
+        // by `index * padding.horizontal` (issue #25).
+        for index in titles.indices {
+            tabView.jump(to: index)
+            tabView.setNeedsLayout()
+            tabView.layoutIfNeeded()
+
+            let item = tabView.itemViews[index]
+            #expect(abs(indicator.frame.origin.x - (item.frame.origin.x + padding.left)) < 0.5)
+            #expect(abs(indicator.frame.width - (item.frame.width - padding.horizontal)) < 0.5)
+        }
     }
 
     // MARK: - BUG 4: boundary items


### PR DESCRIPTION
## Summary

In the `.segmented` tab style, `TabView.resetAdditionViewPosition(index:)` positioned the selection indicator at `adjustCellWidth * index - additionView.padding.left`. Every other placement of the indicator (the flexible style, `setupAdditionView`, `moveAdditionView`, `jump`) *adds* the left padding, so at the first tab the indicator was offset to `-padding.left` and spilled off the leading edge of the tab bar.

This flips the sign so the segmented indicator is inset by the left padding like the other styles.

Reported in #25 and previously proposed in #118.

## Before / After

For the first tab with `additionView.padding.left == 20`:

- Before: `origin.x == -20` (indicator hangs off the left edge)
- After: `origin.x == 20` (indicator inset by the padding)

## Test

Adds a `TabView` test that hosts a segmented tab bar with a non-zero left padding and asserts the indicator sits at `+padding.left`. It fails against the previous code (`origin.x == -20`) and passes with the fix.