### PR TITLE
Adopt Liquid Glass for the example's options button

### DIFF
--- a/Example/Example/MenuViewController.swift
+++ b/Example/Example/MenuViewController.swift
@@ -16,7 +16,9 @@ final class MenuViewController: SwipeMenuViewController {
     private var settings = SwipeMenuSettings()
 
     private lazy var settingsButton: UIButton = {
-        var configuration = UIButton.Configuration.filled()
+        // A prominent Liquid Glass button that floats over the paging content and
+        // refracts what scrolls beneath it.
+        var configuration = UIButton.Configuration.prominentGlass()
         configuration.image = UIImage(systemName: "gearshape")
         configuration.cornerStyle = .capsule
         configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 22, weight: .medium)

--- a/Example/README.md
+++ b/Example/README.md
@@ -2,7 +2,8 @@
 
 A small iOS app that demonstrates `SwipeMenuViewController` and lets you tweak
 `SwipeMenuViewOptions` live. It is written entirely in code — no storyboards —
-with a `UIWindowScene` lifecycle and SF Symbols, and the option-building logic in
+with a `UIWindowScene` lifecycle, SF Symbols, and a Liquid Glass options button,
+and the option-building logic in
 [`SwipeMenuSettings`](./Example/SwipeMenuSettings.swift) is covered by unit tests
 in [`ExampleTests`](./ExampleTests).
 


### PR DESCRIPTION
## Summary

Adopt Liquid Glass in the example app. This is the final step of the example modernization.

The floating options button now uses `UIButton.Configuration.prominentGlass()`, so it renders as an interactive Liquid Glass control (translucent, specular, and refracting the paging content beneath it) on iOS 26 instead of a flat filled button. The options sheet and its navigation bar already pick up Liquid Glass automatically from the iOS 26 SDK.

`.prominentGlass()` (tinted) is used rather than `.glass()` so the floating action button stays clearly discoverable over the light content area.

## Changes

- `MenuViewController`: floating options button `filled()` → `prominentGlass()`.
- Note the Liquid Glass button in the example README.

## Verification

- Builds and runs on the iOS 26 simulator; the button renders as a Liquid Glass control and still presents the options sheet.
