### PR TITLE
Add cornerRadius option for the underline indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `SwipeMenuViewOptions.TabView.ItemView.numberOfLines` to let tab titles wrap onto multiple lines (use `0` for as many lines as the title needs). Defaults to `1`, preserving the previous single-line behavior. Most useful with the `.segmented` style, where a long title would otherwise be truncated.
+- `SwipeMenuViewOptions.TabView.AdditionView.Underline.cornerRadius` to round the corners of the underline indicator (set it to half the underline height for a pill shape). Defaults to `0`, preserving the previous square corners.
 
 ### Fixed
 - The `.segmented` tab style mispositioned the selection indicator when `additionView.padding` had non-zero horizontal insets: the first tab's indicator spilled off the leading edge, and each later tab drifted increasingly to the left. The indicator now aligns with every tab, inset by the padding, consistent with the other tab styles (issue #25).

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -49,6 +49,10 @@ public nonisolated struct SwipeMenuViewOptions: Sendable {
             public nonisolated struct Underline: Sendable {
                 /// Underline height if addition style select `.underline`. Defaults to `2.0`.
                 public var height: CGFloat = 2.0
+
+                /// Corner radius of the underline if addition style select `.underline`.
+                /// Defaults to `0` (square corners). Set it to half of `height` for a pill shape.
+                public var cornerRadius: CGFloat = 0
             }
 
             public nonisolated struct Circle: Sendable {

--- a/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
+++ b/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
@@ -102,10 +102,12 @@ When `addition` is `.underline`, the `underline` group sets the underline thickn
 top-level height on the addition view — the thickness lives on the underline options:
 
 - `height`: the underline thickness. Defaults to `2.0`.
+- `cornerRadius`: the underline's corner radius. Defaults to `0` (square corners). Set it to half the height for a pill shape.
 
 ```swift
 options.tabView.addition = .underline
 options.tabView.additionView.underline.height = 3
+options.tabView.additionView.underline.cornerRadius = 1.5
 ```
 
 ### Circle

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -396,6 +396,7 @@ extension TabView {
         case .underline:
             let itemView = itemViews[currentIndex]
             additionView = UIView(frame: CGRect(x: itemView.frame.origin.x + options.additionView.padding.left, y: itemView.frame.height - options.additionView.padding.vertical, width: itemView.frame.width - options.additionView.padding.horizontal, height: options.additionView.underline.height))
+            additionView.layer.cornerRadius = options.additionView.underline.cornerRadius
             additionView.backgroundColor = options.additionView.backgroundColor
             containerView.addSubview(additionView)
         case .circle:

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -41,6 +41,7 @@ struct SwipeMenuViewOptionsTests {
         let options = SwipeMenuViewOptions()
 
         #expect(options.tabView.additionView.underline.height == 2.0)
+        #expect(options.tabView.additionView.underline.cornerRadius == 0)
         #expect(options.tabView.additionView.animationDuration == 0.3)
         #expect(options.tabView.additionView.isAnimationOnSwipeEnable == true)
         #expect(options.tabView.additionView.padding == .zero)

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -222,6 +222,39 @@ struct TabViewTests {
         #expect(additionViewCount(in: tabView) == 0)
     }
 
+    // MARK: - Underline corner radius
+
+    @Test("The underline indicator has square corners by default")
+    func underlineCornerRadiusDefaultsToSquare() throws {
+        var options = SwipeMenuViewOptions.TabView()
+        options.addition = .underline
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let indicator = try #require(additionView(in: tabView))
+        #expect(indicator.layer.cornerRadius == 0)
+    }
+
+    @Test("underline.cornerRadius is applied to the indicator layer")
+    func underlineCornerRadiusIsApplied() throws {
+        var options = SwipeMenuViewOptions.TabView()
+        options.addition = .underline
+        options.additionView.underline.height = 4
+        // Half the height rounds the underline into a pill.
+        options.additionView.underline.cornerRadius = 2
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        let indicator = try #require(additionView(in: tabView))
+        #expect(indicator.layer.cornerRadius == 2)
+    }
+
     // MARK: - Segmented indicator offset (issue #25)
 
     @Test("Segmented indicator sits inside every tab, inset by the padding")


### PR DESCRIPTION
## Summary

Adds `SwipeMenuViewOptions.TabView.AdditionView.Underline.cornerRadius`, applied to the underline indicator's layer, so the underline can be rounded — set it to half the underline height for a pill shape.

It defaults to `0`, preserving the previous square corners, and mirrors the existing `circle.cornerRadius` option for the `.circle` addition style.

This reworks the hardcoded underline rounding proposed in #118 into a configurable, backward-compatible option.

## Usage

```swift
options.tabView.addition = .underline
options.tabView.additionView.underline.height = 3
options.tabView.additionView.underline.cornerRadius = 1.5 // pill-shaped
```

## Tests

- Options default assertion: `underline.cornerRadius == 0`.
- `TabView` tests: the indicator layer has `cornerRadius == 0` by default and reflects the configured value when set.