### PR TITLE
Add selectedFont option for the selected tab title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `SwipeMenuViewOptions.TabView.ItemView.selectedFont` to use a different title font while a tab is selected. Defaults to the same 14 pt bold system font as `font`, so the title font does not change on selection unless you set it. It affects the selected title's appearance only; in the `.flexible` style item widths are still measured with `font`.
 - `SwipeMenuViewOptions.TabView.ItemView.numberOfLines` to let tab titles wrap onto multiple lines (use `0` for as many lines as the title needs). Defaults to `1`, preserving the previous single-line behavior. Most useful with the `.segmented` style, where a long title would otherwise be truncated.
 - `SwipeMenuViewOptions.TabView.AdditionView.Underline.cornerRadius` to round the corners of the underline indicator (set it to half the underline height for a pill shape). Defaults to `0`, preserving the previous square corners.
 

--- a/Sources/SwipeMenuViewController/SwipeMenuView.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuView.swift
@@ -27,6 +27,13 @@ public nonisolated struct SwipeMenuViewOptions: Sendable {
             /// ItemView font. Defaults to `14 pt as bold SystemFont`.
             public var font: UIFont = UIFont.boldSystemFont(ofSize: 14)
 
+            /// ItemView font used while the item is selected. Defaults to `14 pt as bold SystemFont`,
+            /// matching `font` so the title font does not change on selection unless you set this.
+            ///
+            /// This changes the selected title's appearance only; in the `.flexible` style each item's
+            /// width is still measured with `font`, so a larger `selectedFont` may be truncated.
+            public var selectedFont: UIFont = UIFont.boldSystemFont(ofSize: 14)
+
             /// ItemView clipsToBounds. Defaults to `true`.
             public var clipsToBounds: Bool = true
 

--- a/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
+++ b/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
@@ -56,7 +56,8 @@ The `itemView` group configures each individual tab:
 
 - `width`: the item width, used when `needsAdjustItemViewWidth` is `false`. Defaults to `100.0`.
 - `margin`: the horizontal padding added around the title. Defaults to `5.0`.
-- `font`: the title font. Defaults to a 14 pt bold system font.
+- `font`: the title font when unselected. Defaults to a 14 pt bold system font.
+- `selectedFont`: the title font when selected. Defaults to the same 14 pt bold system font as `font`, so the title font does not change on selection unless you set this. It affects the selected title's appearance only; in the `.flexible` style each item's width is measured with `font`, so a much larger `selectedFont` may be truncated.
 - `clipsToBounds`: whether the item clips its contents. Defaults to `true`.
 - `textColor`: the title color when unselected. Defaults to a gray.
 - `selectedTextColor`: the title color when selected. Defaults to black.
@@ -65,7 +66,8 @@ The `itemView` group configures each individual tab:
 ```swift
 options.tabView.itemView.width = 120
 options.tabView.itemView.margin = 8
-options.tabView.itemView.font = .boldSystemFont(ofSize: 15)
+options.tabView.itemView.font = .systemFont(ofSize: 15)
+options.tabView.itemView.selectedFont = .boldSystemFont(ofSize: 15)
 options.tabView.itemView.textColor = .secondaryLabel
 options.tabView.itemView.selectedTextColor = .label
 options.tabView.itemView.numberOfLines = 2

--- a/Sources/SwipeMenuViewController/TabItemView.swift
+++ b/Sources/SwipeMenuViewController/TabItemView.swift
@@ -12,13 +12,29 @@ final class TabItemView: UIView {
     /// The title color used when the item is selected.
     public var selectedTextColor: UIColor = .white
 
-    /// Whether the item is currently selected. Setting this updates the title color.
+    /// The title font used when the item is not selected.
+    public var font: UIFont = UIFont.boldSystemFont(ofSize: 14) {
+        didSet {
+            if !isSelected { titleLabel.font = font }
+        }
+    }
+
+    /// The title font used when the item is selected.
+    public var selectedFont: UIFont = UIFont.boldSystemFont(ofSize: 14) {
+        didSet {
+            if isSelected { titleLabel.font = selectedFont }
+        }
+    }
+
+    /// Whether the item is currently selected. Setting this updates the title color and font.
     public var isSelected: Bool = false {
         didSet {
             if isSelected {
                 titleLabel.textColor = selectedTextColor
+                titleLabel.font = selectedFont
             } else {
                 titleLabel.textColor = textColor
+                titleLabel.font = font
             }
         }
     }
@@ -40,7 +56,7 @@ final class TabItemView: UIView {
     private func setupLabel() {
         titleLabel = UILabel(frame: bounds)
         titleLabel.textAlignment = .center
-        titleLabel.font = UIFont.boldSystemFont(ofSize: 14)
+        titleLabel.font = font
         titleLabel.textColor = UIColor(red: 140/255, green: 140/255, blue: 140/255, alpha: 1.0)
         titleLabel.backgroundColor = UIColor.clear
         addSubview(titleLabel)

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -256,13 +256,12 @@ open class TabView: UIScrollView {
             tabItemView.clipsToBounds = options.clipsToBounds
             if let title = dataSource.tabView(self, titleForItemAt: index) {
                 tabItemView.titleLabel.text = title
-                tabItemView.titleLabel.font = options.itemView.font
                 tabItemView.titleLabel.numberOfLines = options.itemView.numberOfLines
+                tabItemView.font = options.itemView.font
+                tabItemView.selectedFont = options.itemView.selectedFont
                 tabItemView.textColor = options.itemView.textColor
                 tabItemView.selectedTextColor = options.itemView.selectedTextColor
             }
-
-            tabItemView.isSelected = index == currentIndex
 
             switch options.style {
             case .flexible:
@@ -294,6 +293,11 @@ open class TabView: UIScrollView {
 
                 containerView.addArrangedSubview(tabItemView)
             }
+
+            // Apply selection after the width calc above so each item is measured
+            // with `font`. Setting `isSelected` swaps in `selectedFont`, which must
+            // not influence layout.
+            tabItemView.isSelected = index == currentIndex
 
             itemViews.append(tabItemView)
 

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -32,6 +32,8 @@ struct SwipeMenuViewOptionsTests {
         #expect(options.tabView.itemView.width == 100.0)
         #expect(options.tabView.itemView.margin == 5.0)
         #expect(options.tabView.itemView.font == UIFont.boldSystemFont(ofSize: 14))
+        // Defaults to the same font as `font`, so selection does not change the title font by default.
+        #expect(options.tabView.itemView.selectedFont == UIFont.boldSystemFont(ofSize: 14))
         #expect(options.tabView.itemView.clipsToBounds == true)
         #expect(options.tabView.itemView.numberOfLines == 1)
     }

--- a/Tests/SwipeMenuViewControllerTests/TabItemViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabItemViewTests.swift
@@ -19,6 +19,38 @@ struct TabItemViewTests {
         #expect(item.titleLabel.textColor == item.textColor)
     }
 
+    @Test("isSelected switches the label between the base and selected fonts")
+    func selectionTogglesLabelFont() {
+        let item = TabItemView(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
+        item.font = .systemFont(ofSize: 14)
+        item.selectedFont = .boldSystemFont(ofSize: 20)
+
+        item.isSelected = true
+        #expect(item.titleLabel.font == item.selectedFont)
+
+        item.isSelected = false
+        #expect(item.titleLabel.font == item.font)
+    }
+
+    @Test("Assigning font updates the label only while unselected")
+    func fontAssignmentRespectsSelection() {
+        let item = TabItemView(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
+        let base = UIFont.systemFont(ofSize: 14)
+        let selected = UIFont.boldSystemFont(ofSize: 20)
+
+        // While unselected, the base font drives the label and the selected font does not.
+        item.font = base
+        item.selectedFont = selected
+        #expect(item.titleLabel.font == base)
+
+        // While selected, the selected font drives the label and the base font does not.
+        item.isSelected = true
+        item.selectedFont = selected
+        #expect(item.titleLabel.font == selected)
+        item.font = base
+        #expect(item.titleLabel.font == selected)
+    }
+
     @Test("The label is centered and hosted in the item view")
     func labelIsConfigured() {
         let item = TabItemView(frame: CGRect(x: 0, y: 0, width: 100, height: 44))

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -222,6 +222,67 @@ struct TabViewTests {
         #expect(additionViewCount(in: tabView) == 0)
     }
 
+    // MARK: - Item fonts
+
+    @Test("The selected item uses selectedFont and the rest use font")
+    func selectedFontIsAppliedToSelectedItemOnly() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.itemView.font = .systemFont(ofSize: 14)
+        options.itemView.selectedFont = .boldSystemFont(ofSize: 20)
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // The first item is selected after reload, so it uses the selected font...
+        #expect(tabView.itemViews[0].titleLabel.font == options.itemView.selectedFont)
+        // ...and every other item uses the base font.
+        #expect(tabView.itemViews.dropFirst().allSatisfy { $0.titleLabel.font == options.itemView.font })
+    }
+
+    @Test("Selecting another tab moves the selected font onto it")
+    func selectedFontFollowsSelection() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.itemView.font = .systemFont(ofSize: 14)
+        options.itemView.selectedFont = .boldSystemFont(ofSize: 20)
+
+        let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
+
+        let window = hostTabView(tabView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        tabView.jump(to: 1)
+
+        #expect(tabView.itemViews[1].titleLabel.font == options.itemView.selectedFont)
+        #expect(tabView.itemViews[0].titleLabel.font == options.itemView.font)
+        #expect(tabView.itemViews[2].titleLabel.font == options.itemView.font)
+    }
+
+    @Test("selectedFont does not affect flexible item widths")
+    func selectedFontDoesNotAffectWidth() {
+        var base = SwipeMenuViewOptions.TabView()
+        base.style = .flexible
+        base.itemView.font = .systemFont(ofSize: 14)
+        base.itemView.selectedFont = .systemFont(ofSize: 14)
+
+        var large = base
+        // A much larger selected font must not widen the selected item, because
+        // widths are measured with `font`.
+        large.itemView.selectedFont = .boldSystemFont(ofSize: 40)
+
+        let (baseTab, baseDS) = makeTabView(titles: ["Selected", "B", "C"], options: base)
+        let baseWindow = hostTabView(baseTab)
+        defer { withExtendedLifetime((baseWindow, baseDS)) {} }
+
+        let (largeTab, largeDS) = makeTabView(titles: ["Selected", "B", "C"], options: large)
+        let largeWindow = hostTabView(largeTab)
+        defer { withExtendedLifetime((largeWindow, largeDS)) {} }
+
+        // Item 0 is selected in both tab views; its width must be identical.
+        #expect(abs(baseTab.itemViews[0].frame.width - largeTab.itemViews[0].frame.width) < 0.5)
+    }
+
     // MARK: - Underline corner radius
 
     @Test("The underline indicator has square corners by default")


### PR DESCRIPTION
## Summary

Adds `SwipeMenuViewOptions.TabView.ItemView.selectedFont` so a tab can use a different title font while it is selected. Previously only the title *color* could change on selection, so a common tab-bar design that gives the selected tab a heavier or larger font could not be expressed through the options.

This consolidates two independent community proposals for the same feature and preserves their authorship (commit author + co-author):

- #105 by @amazing-longdd
- #115 by @xysT2W

Their original commits predate the Swift 6 / SPM restructure, so the change is re-applied cleanly against the current source layout.

## Behavior

- Defaults to the same 14 pt bold system font as `font`, so existing behavior is **unchanged** unless the option is set.
- `selectedFont` affects the selected title's appearance only. In the `.flexible` style each item is measured with `font`, so `selectedFont` is applied *after* the width calculation and does not shift item widths (a much larger selected font may therefore be truncated).

```swift
var options = SwipeMenuViewOptions()
options.tabView.itemView.font = .systemFont(ofSize: 15)
options.tabView.itemView.selectedFont = .boldSystemFont(ofSize: 15)
```

## Tests

- `TabItemView`: selection swaps the label between `font` and `selectedFont`; assigning a font respects the current selection state.
- `TabView`: only the selected item uses `selectedFont`, selection moves it to the newly selected tab, and `selectedFont` does not change flexible item widths.
- `SwipeMenuViewOptions`: the documented default.

## Documentation

- Customizing Appearance guide and `CHANGELOG.md` updated.
