### PR TITLE
Fix flexible tab scroll width and reload() page duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 - The `.segmented` tab style mispositioned the selection indicator when `additionView.padding` had non-zero horizontal insets: the first tab's indicator spilled off the leading edge, and each later tab drifted increasingly to the left. The indicator now aligns with every tab, inset by the padding, consistent with the other tab styles (issue #25).
+- The `.flexible` tab style computed its scrollable width by subtracting the right safe-area inset instead of adding it, so on devices with a non-zero right inset (for example landscape with the notch on the left) the last tab could not be scrolled fully into view.
+- `ContentScrollView.reload()` left the previous page views in the view hierarchy while building the new ones, stacking a duplicate set of pages on every call. It now replaces the pages and preserves the current page index.
 
 ## 5.0.0 - 2026-07-05
 

--- a/Sources/SwipeMenuViewController/ContentScrollView.swift
+++ b/Sources/SwipeMenuViewController/ContentScrollView.swift
@@ -76,10 +76,14 @@ open class ContentScrollView: UIScrollView {
 
     /// Rebuilds the page views from the data source.
     ///
-    /// The view must already be in a view hierarchy; when it has no superview
-    /// this method does nothing.
+    /// The current page index is preserved. The view must already be in a view
+    /// hierarchy; when it has no superview this method does nothing.
     public func reload() {
         guard superview != nil else { return }
+        // Discard the previous pages first so a reload replaces them instead of
+        // stacking a second set of page views into the hierarchy.
+        pageViews.forEach { $0.removeFromSuperview() }
+        pageViews = []
         setup()
     }
 

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -338,7 +338,7 @@ open class TabView: UIScrollView {
                     containerView.widthAnchor.constraint(equalToConstant: containerWidth),
                     heightConstraint
                     ])
-                contentSize.width = containerWidth + options.margin * 2 + safeAreaInsets.left - safeAreaInsets.right
+                contentSize.width = containerWidth + options.margin * 2 + safeAreaInsets.left + safeAreaInsets.right
             } else {
                 leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin)
                 NSLayoutConstraint.activate([

--- a/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/ContentScrollViewTests.swift
@@ -75,6 +75,29 @@ struct ContentScrollViewTests {
         #expect(dataSource.requestedIndices == [0, 1, 2, 0, 1, 2])
     }
 
+    @Test("reload() replaces the page views instead of stacking them")
+    func reloadReplacesPageViews() {
+        let baseTag = 700
+        let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 0)
+        let dataSource = StubContentDataSource(pageCount: 3, baseTag: baseTag)
+        contentScrollView.dataSource = dataSource
+
+        let window = hostInWindow(contentScrollView)
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        // Page views are identified by their tag (baseTag + index).
+        func hostedPageViewCount() -> Int {
+            contentScrollView.subviews.count { $0.tag >= baseTag }
+        }
+
+        #expect(hostedPageViewCount() == 3)
+
+        contentScrollView.reload()
+
+        // The previous pages must be gone; only the freshly built set remains.
+        #expect(hostedPageViewCount() == 3)
+    }
+
     @Test("reload() without a superview does nothing")
     func reloadWithoutSuperviewDoesNothing() {
         let contentScrollView = ContentScrollView(frame: CGRect(x: 0, y: 0, width: 375, height: 600), default: 0)

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -112,6 +112,53 @@ struct TabViewTests {
         #expect(abs(total - tabView.frame.width) < 1.0)
     }
 
+    @Test("Flexible content width includes both horizontal safe-area insets")
+    func flexibleContentWidthIncludesSafeAreaInsets() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .flexible
+        options.margin = 0
+        options.isSafeAreaEnabled = true
+        options.needsAdjustItemViewWidth = false
+        options.itemView.width = 100
+
+        let dataSource = StubTabViewDataSource(titles: ["A", "B", "C"])
+        let tabView = TabView(frame: CGRect(x: 0, y: 0, width: 400, height: options.height), options: options)
+        tabView.dataSource = dataSource
+
+        // Host inside a view controller so its safe area can be driven via
+        // additionalSafeAreaInsets (a UIViewController-only property).
+        let viewController = UIViewController()
+        viewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 667))
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        tabView.translatesAutoresizingMaskIntoConstraints = false
+        viewController.view.addSubview(tabView)
+        NSLayoutConstraint.activate([
+            tabView.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            tabView.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+            tabView.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+            tabView.heightAnchor.constraint(equalToConstant: options.height)
+        ])
+        viewController.view.layoutIfNeeded()
+        // Build the items against the stable frame with the safe area in place.
+        tabView.reloadData()
+        viewController.view.layoutIfNeeded()
+
+        // Precondition: the safe area really reached the tab view.
+        #expect(tabView.safeAreaInsets.left == 20)
+        #expect(tabView.safeAreaInsets.right == 20)
+
+        // The container is laid out at leading inset + margin, so the scrollable
+        // width must cover the items plus the margin and inset on *both* sides;
+        // otherwise the last item cannot be scrolled fully into view.
+        let itemsWidth: CGFloat = 100 * 3
+        let expectedWidth = itemsWidth + tabView.safeAreaInsets.left + tabView.safeAreaInsets.right
+        #expect(abs(tabView.contentSize.width - expectedWidth) < 1.0)
+    }
+
     @Test("With safe area disabled, a safe-area change does not shrink segmented items")
     func safeAreaDisabledIgnoresInsetChanges() {
         var options = SwipeMenuViewOptions.TabView()


### PR DESCRIPTION
## Summary

Two small bug fixes, one commit each, both with regression tests.

### Flexible tab content width lost the right safe-area inset

With the `.flexible` style and safe-area layout enabled, the constraint pass computed the scrollable width as

```
containerWidth + margin * 2 + safeAreaInsets.left - safeAreaInsets.right
```

subtracting the right inset instead of adding it, while the container itself is laid out at `leading = margin + safeAreaInsets.left`. On devices with a non-zero right inset (e.g. landscape with the notch on the left) the content size came up `2 × right` short, so the last tab could not be scrolled fully into view. The initial sizing in `setupContainerView(dataSource:)` and the clamping in `focus(on:)` already added both insets — the constraint pass now agrees with them.

### `ContentScrollView.reload()` stacked duplicate page views

`reload()` rebuilt the pages without discarding the previous ones, so every call added a second full set of page views to the hierarchy, constrained after the old ones. It now removes the stale page views before rebuilding and preserves the current page index.

## Tests

- New: flexible content width includes both horizontal safe-area insets (driven through `additionalSafeAreaInsets` on a hosting view controller, with preconditions that the insets really reached the tab view); `reload()` replaces the page views instead of stacking them.
- All 69 package tests pass locally on the iPhone 17 simulator (Xcode 26.5).

## Changelog

Both fixes are recorded under **Unreleased → Fixed**.