### PR TITLE
Deduplicate the safe-area branches in TabView's layout code

### DIFF
--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -74,6 +74,12 @@ open class TabView: UIScrollView {
     private var leftMarginConstraint: NSLayoutConstraint = .init()
     private var widthConstraint: NSLayoutConstraint = .init()
 
+    /// The safe-area insets the layout honors: the view's real insets when
+    /// safe-area layout is enabled through the options, `.zero` otherwise.
+    private var layoutSafeAreaInsets: UIEdgeInsets {
+        return options.isSafeAreaEnabled ? safeAreaInsets : .zero
+    }
+
     public init(frame: CGRect, options: SwipeMenuViewOptions.TabView? = nil) {
         super.init(frame: frame)
 
@@ -109,7 +115,7 @@ open class TabView: UIScrollView {
 
         leftMarginConstraint.constant = options.margin + safeAreaInsets.left
         if options.style == .segmented {
-            widthConstraint.constant = options.margin * -2 - safeAreaInsets.left - safeAreaInsets.right
+            widthConstraint.constant = -(options.margin * 2 + safeAreaInsets.left + safeAreaInsets.right)
         }
 
         layoutIfNeeded()
@@ -119,16 +125,9 @@ open class TabView: UIScrollView {
 
         if options.style == .segmented { return }
 
-        let offset: CGFloat
-        let contentWidth: CGFloat
-
-        if options.isSafeAreaEnabled {
-            offset = target.center.x + options.margin + safeAreaInsets.left - self.frame.width / 2
-            contentWidth = containerView.frame.width + options.margin * 2 + safeAreaInsets.left + safeAreaInsets.right
-        } else {
-            offset = target.center.x + options.margin - self.frame.width / 2
-            contentWidth = containerView.frame.width + options.margin * 2
-        }
+        let inset = layoutSafeAreaInsets
+        let offset = target.center.x + options.margin + inset.left - self.frame.width / 2
+        let contentWidth = containerView.frame.width + options.margin * 2 + inset.horizontal
 
         if offset < 0 || self.frame.width > contentWidth {
             self.setContentOffset(CGPoint(x: 0, y: 0), animated: animated)
@@ -218,24 +217,19 @@ open class TabView: UIScrollView {
             containerHeight = frame.height
         }
 
+        // The container frame is provisional: layout(containerView:containerWidth:)
+        // replaces it with constraints. Its size still matters before that pass,
+        // because the item views measure themselves against it.
+        let inset = layoutSafeAreaInsets
+
         switch options.style {
         case .flexible:
             let containerWidth = options.itemView.width * CGFloat(itemCount)
-            if options.isSafeAreaEnabled {
-                contentSize = CGSize(width: containerWidth + options.margin * 2 + safeAreaInsets.left + safeAreaInsets.right, height: options.height)
-                containerView.frame = CGRect(x: 0, y: options.margin + safeAreaInsets.left, width: containerWidth, height: containerHeight)
-            } else {
-                contentSize = CGSize(width: containerWidth + options.margin * 2, height: options.height)
-                containerView.frame = CGRect(x: 0, y: options.margin, width: containerWidth, height: containerHeight)
-            }
+            contentSize = CGSize(width: containerWidth + options.margin * 2 + inset.horizontal, height: options.height)
+            containerView.frame = CGRect(x: 0, y: options.margin, width: containerWidth, height: containerHeight)
         case .segmented:
-            if options.isSafeAreaEnabled {
-                contentSize = CGSize(width: frame.width, height: options.height)
-                containerView.frame = CGRect(x: 0, y: options.margin + safeAreaInsets.left, width: frame.width - options.margin * 2 - safeAreaInsets.left - safeAreaInsets.right, height: containerHeight)
-            } else {
-                contentSize = CGSize(width: frame.width, height: options.height)
-                containerView.frame = CGRect(x: 0, y: options.margin, width: frame.width - options.margin * 2, height: containerHeight)
-            }
+            contentSize = CGSize(width: frame.width, height: options.height)
+            containerView.frame = CGRect(x: 0, y: options.margin, width: frame.width - options.margin * 2 - inset.horizontal, height: containerHeight)
         }
 
         containerView.backgroundColor = .clear
@@ -266,30 +260,17 @@ open class TabView: UIScrollView {
             switch options.style {
             case .flexible:
                 if options.needsAdjustItemViewWidth {
-                    var adjustCellSize = tabItemView.frame.size
-                    adjustCellSize.width = tabItemView.titleLabel.sizeThatFits(containerView.frame.size).width + options.itemView.margin * 2
-                    tabItemView.frame.size = adjustCellSize
-
-                    containerView.addArrangedSubview(tabItemView)
-
-                    NSLayoutConstraint.activate([
-                        tabItemView.widthAnchor.constraint(equalToConstant: adjustCellSize.width)
-                        ])
-                } else {
-                    containerView.addArrangedSubview(tabItemView)
-
-                    NSLayoutConstraint.activate([
-                        tabItemView.widthAnchor.constraint(equalToConstant: options.itemView.width)
-                        ])
+                    tabItemView.frame.size.width = tabItemView.titleLabel.sizeThatFits(containerView.frame.size).width + options.itemView.margin * 2
                 }
+
+                containerView.addArrangedSubview(tabItemView)
+
+                NSLayoutConstraint.activate([
+                    tabItemView.widthAnchor.constraint(equalToConstant: tabItemView.frame.width)
+                    ])
             case .segmented:
-                let adjustCellSize: CGSize
-                if options.isSafeAreaEnabled {
-                    adjustCellSize = CGSize(width: (frame.width - options.margin * 2 - safeAreaInsets.left - safeAreaInsets.right) / CGFloat(itemCount), height: tabItemView.frame.size.height)
-                } else {
-                    adjustCellSize = CGSize(width: (frame.width - options.margin * 2) / CGFloat(itemCount), height: tabItemView.frame.size.height)
-                }
-                tabItemView.frame.size = adjustCellSize
+                let inset = layoutSafeAreaInsets
+                tabItemView.frame.size.width = (frame.width - options.margin * 2 - inset.horizontal) / CGFloat(itemCount)
 
                 containerView.addArrangedSubview(tabItemView)
             }
@@ -327,48 +308,26 @@ open class TabView: UIScrollView {
             heightConstraint = containerView.heightAnchor.constraint(equalToConstant: options.height)
         }
 
+        let inset = layoutSafeAreaInsets
+        leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin + inset.left)
+
         switch options.style {
         case .flexible:
-            if options.isSafeAreaEnabled {
-                leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin + safeAreaInsets.left)
-
-                NSLayoutConstraint.activate([
-                    containerView.topAnchor.constraint(equalTo: self.topAnchor),
-                    leftMarginConstraint,
-                    containerView.widthAnchor.constraint(equalToConstant: containerWidth),
-                    heightConstraint
-                    ])
-                contentSize.width = containerWidth + options.margin * 2 + safeAreaInsets.left + safeAreaInsets.right
-            } else {
-                leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin)
-                NSLayoutConstraint.activate([
-                    containerView.topAnchor.constraint(equalTo: self.topAnchor),
-                    leftMarginConstraint,
-                    containerView.widthAnchor.constraint(equalToConstant: containerWidth),
-                    heightConstraint
-                    ])
-                contentSize.width = containerWidth + options.margin * 2
-            }
+            NSLayoutConstraint.activate([
+                containerView.topAnchor.constraint(equalTo: self.topAnchor),
+                leftMarginConstraint,
+                containerView.widthAnchor.constraint(equalToConstant: containerWidth),
+                heightConstraint
+                ])
+            contentSize.width = containerWidth + options.margin * 2 + inset.horizontal
         case .segmented:
-            if options.isSafeAreaEnabled {
-                leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin + safeAreaInsets.left)
-                widthConstraint = containerView.widthAnchor.constraint(equalTo: self.widthAnchor, constant: options.margin * -2 - safeAreaInsets.left - safeAreaInsets.right)
-                NSLayoutConstraint.activate([
-                    containerView.topAnchor.constraint(equalTo: self.topAnchor),
-                    leftMarginConstraint,
-                    widthConstraint,
-                    heightConstraint
-                    ])
-            } else {
-                leftMarginConstraint = containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: options.margin)
-                widthConstraint = containerView.widthAnchor.constraint(equalTo: self.widthAnchor, constant: options.margin * -2)
-                NSLayoutConstraint.activate([
-                    containerView.topAnchor.constraint(equalTo: self.topAnchor),
-                    leftMarginConstraint,
-                    widthConstraint,
-                    heightConstraint
-                    ])
-            }
+            widthConstraint = containerView.widthAnchor.constraint(equalTo: self.widthAnchor, constant: -(options.margin * 2 + inset.horizontal))
+            NSLayoutConstraint.activate([
+                containerView.topAnchor.constraint(equalTo: self.topAnchor),
+                leftMarginConstraint,
+                widthConstraint,
+                heightConstraint
+                ])
 
             contentSize = .zero
         }
@@ -446,12 +405,8 @@ extension TabView {
         // that width is the indicator's per-tab stride. The indicator itself is
         // inset by the horizontal padding. Using the padding-adjusted width as the
         // stride would drift the indicator left by `index * padding.horizontal`.
-        let cellWidth: CGFloat
-        if options.isSafeAreaEnabled && safeAreaInsets != .zero {
-            cellWidth = (frame.width - options.margin * 2 - safeAreaInsets.left - safeAreaInsets.right) / CGFloat(dataSource.numberOfItems(in: self))
-        } else {
-            cellWidth = (frame.width - options.margin * 2) / CGFloat(dataSource.numberOfItems(in: self))
-        }
+        let inset = layoutSafeAreaInsets
+        let cellWidth = (frame.width - options.margin * 2 - inset.horizontal) / CGFloat(dataSource.numberOfItems(in: self))
 
         additionView.frame.origin.x = cellWidth * CGFloat(index) + options.additionView.padding.left
         additionView.frame.size.width = cellWidth - options.additionView.padding.horizontal

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -159,6 +159,49 @@ struct TabViewTests {
         #expect(abs(tabView.contentSize.width - expectedWidth) < 1.0)
     }
 
+    @Test("With safe area enabled, segmented items shrink by the horizontal insets")
+    func safeAreaEnabledShrinksSegmentedItems() {
+        var options = SwipeMenuViewOptions.TabView()
+        options.style = .segmented
+        options.margin = 0
+        options.isSafeAreaEnabled = true
+
+        let dataSource = StubTabViewDataSource(titles: ["A", "B", "C", "D"])
+        let tabView = TabView(frame: CGRect(x: 0, y: 0, width: 400, height: options.height), options: options)
+        tabView.dataSource = dataSource
+
+        // Host inside a view controller so its safe area can be driven via
+        // additionalSafeAreaInsets (a UIViewController-only property).
+        let viewController = UIViewController()
+        viewController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 667))
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        defer { withExtendedLifetime((window, dataSource)) {} }
+
+        tabView.translatesAutoresizingMaskIntoConstraints = false
+        viewController.view.addSubview(tabView)
+        NSLayoutConstraint.activate([
+            tabView.topAnchor.constraint(equalTo: viewController.view.topAnchor),
+            tabView.leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor),
+            tabView.trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor),
+            tabView.heightAnchor.constraint(equalToConstant: options.height)
+        ])
+        viewController.view.layoutIfNeeded()
+        // Build the items against the stable frame with the safe area in place.
+        tabView.reloadData()
+        viewController.view.layoutIfNeeded()
+
+        // Precondition: the safe area really reached the tab view.
+        #expect(tabView.safeAreaInsets.left == 20)
+        #expect(tabView.safeAreaInsets.right == 20)
+
+        // The items share the width that remains after both insets.
+        let total = tabView.itemViews.reduce(0) { $0 + $1.frame.width }
+        let expected = tabView.frame.width - tabView.safeAreaInsets.left - tabView.safeAreaInsets.right
+        #expect(abs(total - expected) < 1.0)
+    }
+
     @Test("With safe area disabled, a safe-area change does not shrink segmented items")
     func safeAreaDisabledIgnoresInsetChanges() {
         var options = SwipeMenuViewOptions.TabView()


### PR DESCRIPTION
## Summary

Pure refactor of `TabView`'s layout code; no behavior change intended.

Every layout computation branched on `options.isSafeAreaEnabled` and repeated the same formula with and without the insets — `focus(on:)`, `setupContainerView`, `setupTabItemViews`, `layout(containerView:containerWidth:)` (which also branched per style, giving four near-identical constraint blocks), and `resetAdditionViewPosition`. This PR introduces one private helper:

```swift
/// The safe-area insets the layout honors: the view's real insets when
/// safe-area layout is enabled through the options, .zero otherwise.
private var layoutSafeAreaInsets: UIEdgeInsets
```

and collapses each branch pair into a single expression (using the existing `UIEdgeInsets.horizontal` helper).

Details worth reviewing:

- `resetAdditionViewPosition` previously used the inset formula only when `isSafeAreaEnabled && safeAreaInsets != .zero`; the extra non-zero check is dropped because subtracting zero insets is equivalent.
- `setupContainerView` set the provisional container frame's vertical origin to `margin + safeAreaInsets.left` (a horizontal inset in a vertical coordinate). The origin is never observable — the constraint pass replaces it, and only the provisional *size* feeds the item measurement — so it is now just `margin`, with a comment explaining what the provisional frame is for.
- The flexible item branch applies the width adjustment first and then shares the `addArrangedSubview`/width-constraint code; the constraint pins the (possibly adjusted) frame width exactly as before.
- The segmented width constant `margin * -2 - left - right` is written as `-(margin * 2 + inset.horizontal)`.

## Tests

- New: with safe area **enabled**, segmented items shrink by the horizontal insets (driven through `additionalSafeAreaInsets`; mirrors the existing disabled-safe-area test).
- The safe-area content-width and indicator-geometry tests added in #154/#155 pin the other collapsed formulas.
- All 70 package tests pass locally on the iPhone 17 simulator (Xcode 26.5).