### PR TITLE
Rename Boolean options to follow Swift naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Breaking
+- Renamed three `SwipeMenuViewOptions` properties to follow Swift API naming conventions. The old spellings have been removed:
+  - `TabView.needsAdjustItemViewWidth` → `TabView.adjustsItemViewWidth`
+  - `TabView.needsConvertTextColorRatio` → `TabView.interpolatesTextColorOnSwipe`
+  - `TabView.AdditionView.isAnimationOnSwipeEnable` → `TabView.AdditionView.isAnimationOnSwipeEnabled`
+
 ### Added
 - `SwipeMenuViewOptions.TabView.ItemView.selectedFont` to use a different title font while a tab is selected. Defaults to the same 14 pt bold system font as `font`, so the title font does not change on selection unless you set it. It affects the selected title's appearance only; in the `.flexible` style item widths are still measured with `font`.
 - `SwipeMenuViewOptions.TabView.ItemView.numberOfLines` to let tab titles wrap onto multiple lines (use `0` for as many lines as the title needs). Defaults to `1`, preserving the previous single-line behavior. Most useful with the `.segmented` style, where a long title would otherwise be truncated.

--- a/Example/Example/SwipeMenuSettings.swift
+++ b/Example/Example/SwipeMenuSettings.swift
@@ -89,7 +89,7 @@ struct SwipeMenuSettings: Equatable {
         var options = SwipeMenuViewOptions()
 
         options.tabView.margin = tabMargin
-        options.tabView.needsAdjustItemViewWidth = adjustsItemWidthToFit
+        options.tabView.adjustsItemViewWidth = adjustsItemWidthToFit
         options.tabView.itemView.width = itemWidth
         options.tabView.itemView.textColor = .secondaryLabel
         options.tabView.additionView.backgroundColor = .label

--- a/Example/ExampleTests/SwipeMenuSettingsTests.swift
+++ b/Example/ExampleTests/SwipeMenuSettingsTests.swift
@@ -13,7 +13,7 @@ struct SwipeMenuSettingsTests {
         #expect(options.tabView.style == .flexible)
         #expect(options.tabView.addition == .underline)
         #expect(options.tabView.margin == 0)
-        #expect(options.tabView.needsAdjustItemViewWidth)
+        #expect(options.tabView.adjustsItemViewWidth)
         #expect(options.tabView.itemView.width == 100)
         #expect(options.contentScrollView.isScrollEnabled)
     }
@@ -91,7 +91,7 @@ struct SwipeMenuSettingsTests {
 
         #expect(options.tabView.margin == 12)
         #expect(options.tabView.itemView.width == 220)
-        #expect(!options.tabView.needsAdjustItemViewWidth)
+        #expect(!options.tabView.adjustsItemViewWidth)
         #expect(!options.contentScrollView.isScrollEnabled)
     }
 

--- a/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
+++ b/Sources/SwipeMenuViewController/SwipeMenuViewController.docc/CustomizingAppearance.md
@@ -34,8 +34,8 @@ top-level `isSafeAreaEnabled` toggles the safe-area behavior of both at once.
 - `clipsToBounds`: whether the bar clips its contents. Defaults to `true`.
 - `style`: `.flexible` (items sized to their content) or `.segmented` (items share the width equally). Defaults to `.flexible`.
 - `addition`: the selection indicator — `.underline`, `.circle`, or `.none`. Defaults to `.underline`.
-- `needsAdjustItemViewWidth`: whether flexible item widths are adjusted to fit their titles. Defaults to `true`.
-- `needsConvertTextColorRatio`: whether the item text color interpolates toward the selected color as you swipe. Defaults to `true`.
+- `adjustsItemViewWidth`: whether flexible item widths are adjusted to fit their titles. Defaults to `true`.
+- `interpolatesTextColorOnSwipe`: whether the item text color interpolates toward the selected color as you swipe. Defaults to `true`.
 - `isSafeAreaEnabled`: whether the bar respects the safe area. Defaults to `true`.
 
 ```swift
@@ -45,8 +45,8 @@ options.tabView.margin = 8
 options.tabView.backgroundColor = .systemBackground
 options.tabView.style = .flexible
 options.tabView.addition = .underline
-options.tabView.needsAdjustItemViewWidth = true
-options.tabView.needsConvertTextColorRatio = true
+options.tabView.adjustsItemViewWidth = true
+options.tabView.interpolatesTextColorOnSwipe = true
 options.tabView.isSafeAreaEnabled = true
 ```
 
@@ -54,7 +54,7 @@ options.tabView.isSafeAreaEnabled = true
 
 The `itemView` group configures each individual tab:
 
-- `width`: the item width, used when `needsAdjustItemViewWidth` is `false`. Defaults to `100.0`.
+- `width`: the item width, used when `adjustsItemViewWidth` is `false`. Defaults to `100.0`.
 - `margin`: the horizontal padding added around the title. Defaults to `5.0`.
 - `font`: the title font when unselected. Defaults to a 14 pt bold system font.
 - `selectedFont`: the title font when selected. Defaults to the same 14 pt bold system font as `font`, so the title font does not change on selection unless you set this. It affects the selected title's appearance only; in the `.flexible` style each item's width is measured with `font`, so a much larger `selectedFont` may be truncated.
@@ -88,14 +88,14 @@ The `additionView` group configures the selection indicator drawn behind or bene
 - `padding`: insets applied to the indicator. Defaults to `.zero`.
 - `backgroundColor`: the indicator color. Defaults to `.black`.
 - `animationDuration`: the duration used when animating the indicator to a tapped tab. Defaults to `0.3`.
-- `isAnimationOnSwipeEnable`: whether the indicator follows your finger continuously while swiping. When `false`, it jumps to the destination tab instead. Defaults to `true`.
+- `isAnimationOnSwipeEnabled`: whether the indicator follows your finger continuously while swiping. When `false`, it jumps to the destination tab instead. Defaults to `true`.
 
 ```swift
 options.tabView.addition = .underline
 options.tabView.additionView.padding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
 options.tabView.additionView.backgroundColor = .systemBlue
 options.tabView.additionView.animationDuration = 0.25
-options.tabView.additionView.isAnimationOnSwipeEnable = true
+options.tabView.additionView.isAnimationOnSwipeEnabled = true
 ```
 
 ### Underline

--- a/Sources/SwipeMenuViewController/SwipeMenuViewOptions.swift
+++ b/Sources/SwipeMenuViewController/SwipeMenuViewOptions.swift
@@ -81,8 +81,10 @@ public nonisolated struct SwipeMenuViewOptions: Sendable {
             /// AdditionView animating duration. Defaults to `0.3`.
             public var animationDuration: Double = 0.3
 
-            /// AdditionView swipe animation disable feature. Defaults to 'true'
-            public var isAnimationOnSwipeEnable: Bool = true
+            /// Whether the addition view continuously tracks the finger while the content is
+            /// swiped. When `false`, it animates to the destination tab once the page changes
+            /// instead. Defaults to `true`.
+            public var isAnimationOnSwipeEnabled: Bool = true
 
             /// Underline style options.
             public var underline = Underline()
@@ -109,11 +111,14 @@ public nonisolated struct SwipeMenuViewOptions: Sendable {
         /// TabView addition. Defaults to `.underline`. Addition type has [`.underline`, `.circle`, `.none`].
         public var addition: Addition = .underline
 
-        /// TabView adjust width or not. Defaults to `true`.
-        public var needsAdjustItemViewWidth: Bool = true
+        /// Whether each `.flexible` item is sized to fit its title (plus ``ItemView/margin``
+        /// on both sides) instead of using the fixed ``ItemView/width``. Defaults to `true`.
+        public var adjustsItemViewWidth: Bool = true
 
-        /// Convert the text color of ItemView to selected text color by scroll rate of ContentScrollView. Defaults to `true`.
-        public var needsConvertTextColorRatio: Bool = true
+        /// Whether tab titles crossfade between ``ItemView/textColor`` and
+        /// ``ItemView/selectedTextColor`` in proportion to the swipe progress. When `false`,
+        /// titles switch color only when the selection changes. Defaults to `true`.
+        public var interpolatesTextColorOnSwipe: Bool = true
 
         /// TabView enable safeAreaLayout. Defaults to `true`.
         public var isSafeAreaEnabled: Bool = true

--- a/Sources/SwipeMenuViewController/TabView.swift
+++ b/Sources/SwipeMenuViewController/TabView.swift
@@ -259,7 +259,7 @@ open class TabView: UIScrollView {
 
             switch options.style {
             case .flexible:
-                if options.needsAdjustItemViewWidth {
+                if options.adjustsItemViewWidth {
                     tabItemView.frame.size.width = tabItemView.titleLabel.sizeThatFits(containerView.frame.size).width + options.itemView.margin * 2
                 }
 
@@ -388,7 +388,7 @@ extension TabView {
 
         additionView.frame.origin.x = target.frame.origin.x + options.additionView.padding.left
 
-        if options.needsAdjustItemViewWidth {
+        if options.adjustsItemViewWidth {
             let cellWidth = itemViews[index].frame.width
             additionView.frame.size.width = cellWidth - options.additionView.padding.horizontal
         }
@@ -431,13 +431,13 @@ extension TabView {
 
         guard let currentItem else { return }
 
-        if options.additionView.isAnimationOnSwipeEnable {
+        if options.additionView.isAnimationOnSwipeEnabled {
             switch direction {
             case .forward:
                 if let nextItem {
                     additionView.frame.origin.x = currentItem.frame.origin.x + (nextItem.frame.origin.x - currentItem.frame.origin.x) * ratio + options.additionView.padding.left
                     additionView.frame.size.width = currentItem.frame.size.width + (nextItem.frame.size.width - currentItem.frame.size.width) * ratio - options.additionView.padding.horizontal
-                    if options.needsConvertTextColorRatio {
+                    if options.interpolatesTextColorOnSwipe {
                         nextItem.titleLabel.textColor = options.itemView.textColor.convert(to: options.itemView.selectedTextColor, multiplier: ratio)
                         currentItem.titleLabel.textColor = options.itemView.selectedTextColor.convert(to: options.itemView.textColor, multiplier: ratio)
                     }
@@ -446,7 +446,7 @@ extension TabView {
                 if let previousItem {
                     additionView.frame.origin.x = previousItem.frame.origin.x + (currentItem.frame.origin.x - previousItem.frame.origin.x) * ratio + options.additionView.padding.left
                     additionView.frame.size.width = previousItem.frame.size.width + (currentItem.frame.size.width - previousItem.frame.size.width) * ratio - options.additionView.padding.horizontal
-                    if options.needsConvertTextColorRatio {
+                    if options.interpolatesTextColorOnSwipe {
                         previousItem.titleLabel.textColor = options.itemView.selectedTextColor.convert(to: options.itemView.textColor, multiplier: ratio)
                         currentItem.titleLabel.textColor = options.itemView.textColor.convert(to: options.itemView.selectedTextColor, multiplier: ratio)
                     }

--- a/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/SwipeMenuViewOptionsTests.swift
@@ -20,8 +20,8 @@ struct SwipeMenuViewOptionsTests {
         #expect(options.tabView.margin == 0.0)
         #expect(options.tabView.style == .flexible)
         #expect(options.tabView.addition == .underline)
-        #expect(options.tabView.needsAdjustItemViewWidth == true)
-        #expect(options.tabView.needsConvertTextColorRatio == true)
+        #expect(options.tabView.adjustsItemViewWidth == true)
+        #expect(options.tabView.interpolatesTextColorOnSwipe == true)
         #expect(options.tabView.isSafeAreaEnabled == true)
     }
 
@@ -45,7 +45,7 @@ struct SwipeMenuViewOptionsTests {
         #expect(options.tabView.additionView.underline.height == 2.0)
         #expect(options.tabView.additionView.underline.cornerRadius == 0)
         #expect(options.tabView.additionView.animationDuration == 0.3)
-        #expect(options.tabView.additionView.isAnimationOnSwipeEnable == true)
+        #expect(options.tabView.additionView.isAnimationOnSwipeEnabled == true)
         #expect(options.tabView.additionView.padding == .zero)
     }
 

--- a/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
+++ b/Tests/SwipeMenuViewControllerTests/TabViewTests.swift
@@ -73,7 +73,7 @@ struct TabViewTests {
     func flexibleFixedWidth() {
         var options = SwipeMenuViewOptions.TabView()
         options.style = .flexible
-        options.needsAdjustItemViewWidth = false
+        options.adjustsItemViewWidth = false
         options.itemView.width = 100
 
         let (tabView, dataSource) = makeTabView(titles: ["A", "B", "C"], options: options)
@@ -118,7 +118,7 @@ struct TabViewTests {
         options.style = .flexible
         options.margin = 0
         options.isSafeAreaEnabled = true
-        options.needsAdjustItemViewWidth = false
+        options.adjustsItemViewWidth = false
         options.itemView.width = 100
 
         let dataSource = StubTabViewDataSource(titles: ["A", "B", "C"])
@@ -486,7 +486,7 @@ struct TabViewTests {
     @Test("A forward swipe fades the current and next labels by the ratio")
     func forwardSwipeInterpolatesNeighborColors() {
         var options = SwipeMenuViewOptions.TabView()
-        options.needsConvertTextColorRatio = true
+        options.interpolatesTextColorOnSwipe = true
         // Use pure black/white endpoints so the midpoint is an unambiguous gray.
         options.itemView.textColor = .black
         options.itemView.selectedTextColor = .white


### PR DESCRIPTION
## Summary

Three `SwipeMenuViewOptions` properties had names that read as broken English and ignored the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/) conventions for Boolean assertions. This PR renames them; **the old spellings are removed** (breaking change, recorded under Unreleased → Breaking in the changelog):

| Old | New | Rationale |
|---|---|---|
| `TabView.needsAdjustItemViewWidth` | `adjustsItemViewWidth` | UIKit's `adjusts…` pattern (e.g. `adjustsFontSizeToFitWidth`) |
| `TabView.needsConvertTextColorRatio` | `interpolatesTextColorOnSwipe` | says what happens: titles crossfade between `textColor` and `selectedTextColor` in proportion to the swipe progress |
| `TabView.AdditionView.isAnimationOnSwipeEnable` | `isAnimationOnSwipeEnabled` | fixes the `is…Enable` grammar |

The doc comments for the renamed options now describe the behavior precisely (the old ones, e.g. *"AdditionView swipe animation disable feature. Defaults to 'true'"*, did not). The DocC article, example app, and tests are updated to the new names; no references to the old spellings remain.

## Tests

- Existing behavior tests for these options (fixed-width items, text-color interpolation, defaults) now exercise the new names.
- All 70 package tests and the 8 example-app tests pass locally on the iPhone 17 simulator (Xcode 26.5).