### PR TITLE
Add a timeout to the review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ jobs:
   claude-review:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Completes the timeout pass from #159 by giving the review job a 20-minute cap (observed runs take 1–3 minutes).

This one-line change ships in its own PR because the review action validates that its workflow file matches the default branch and skips itself on any PR that edits this file — the automated review will therefore not run here by design. All required checks still apply.