### PR TITLE
Add contributor guide and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this PR change, and why? Link related issues with "Fixes #123". -->
+
+## Checklist
+
+- [ ] Unit tests cover the change (bug fixes include a regression test)
+- [ ] `xcodebuild test -scheme SwipeMenuViewController` passes locally
+- [ ] `swift format lint --strict` passes and the tree is formatter-clean
+- [ ] Public API changes update the DocC documentation
+- [ ] User-facing changes have a CHANGELOG entry under **Unreleased**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to SwipeMenuViewController
+
+Thank you for considering a contribution! Bug reports, fixes, documentation
+improvements, and well-scoped features are all welcome. This document explains
+how to get the project running locally and what a pull request needs before it
+can be merged.
+
+## Requirements
+
+- Xcode 26.0 or later (Swift 6.2 toolchain)
+- [XcodeGen](https://github.com/yonaskolb/XcodeGen) — only if you work on the example app
+
+## Project layout
+
+| Path | What it is |
+|---|---|
+| `Package.swift` | Swift package manifest — the library is SPM-only |
+| `Sources/SwipeMenuViewController/` | Library sources and the DocC catalog |
+| `Tests/SwipeMenuViewControllerTests/` | Unit tests (Swift Testing, run on the iOS simulator) |
+| `Example/` | Demo app consuming the library as a local package |
+
+## Building and testing
+
+Open the package directly in Xcode (`File ▸ Open… ▸ Package.swift`) or run the
+tests from the command line against any available iPhone simulator:
+
+```sh
+xcodebuild test \
+  -scheme SwipeMenuViewController \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Replace `iPhone 17` with any simulator you have installed
+(`xcrun simctl list devices available`).
+
+## Example app
+
+The example app's Xcode project is generated — `Example.xcodeproj` is not
+committed, and [`Example/project.yml`](Example/project.yml) is the source of
+truth:
+
+```sh
+cd Example
+xcodegen generate
+open Example.xcodeproj
+```
+
+Re-run `xcodegen generate` whenever you change `project.yml`. See the
+[Example README](Example/README.md) for details.
+
+## Formatting and linting
+
+The codebase is formatted and linted with the Swift toolchain's built-in
+[swift-format](https://github.com/swiftlang/swift-format); the configuration
+lives in [`.swift-format`](.swift-format). Before pushing:
+
+```sh
+swift format --in-place --recursive --parallel Sources Tests Example/Example Example/ExampleTests Package.swift
+swift format lint --strict --recursive --parallel Sources Tests Example/Example Example/ExampleTests Package.swift
+```
+
+CI fails if the tree is not formatter-clean or any lint rule fires.
+
+## Documentation
+
+The public API is documented with DocC (`Sources/SwipeMenuViewController/SwipeMenuViewController.docc`).
+If your change touches the public API, update the documentation comments and,
+where relevant, the articles. CI builds the documentation with warnings treated
+as errors, so broken symbol links fail the build:
+
+```sh
+xcodebuild docbuild \
+  -scheme SwipeMenuViewController \
+  -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO \
+  OTHER_DOCC_FLAGS='--warnings-as-errors'
+```
+
+The published documentation at
+[yysskk.github.io/SwipeMenuViewController](https://yysskk.github.io/SwipeMenuViewController/documentation/swipemenuviewcontroller/)
+is deployed automatically from `main`.
+
+## Changelog
+
+User-facing changes (new options, behavior changes, bug fixes) get an entry in
+the **Unreleased** section of [CHANGELOG.md](CHANGELOG.md). Internal refactors
+and CI changes do not need one.
+
+## Pull requests
+
+1. Fork and create a topic branch from `main`.
+2. Keep the PR focused; unrelated changes belong in separate PRs.
+3. Add or update unit tests for what you change — bug fixes need a regression
+   test that fails without the fix.
+4. Make sure the test suite, the formatter, and the documentation build all
+   pass locally.
+5. Fill in the pull request template. CI (tests, example build, documentation,
+   swift-format) must be green before review.
+
+For anything larger than a bug fix, consider opening an issue first to discuss
+the direction.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ You can also build the documentation locally in Xcode with **Product ▸ Build D
 
 ## Contributing
 
-Bug reports and pull requests are welcome. Please open an issue using one of the templates, and make sure the test suite passes (`xcodebuild test -scheme SwipeMenuViewController -destination 'platform=iOS Simulator,name=iPhone 16'`).
+Bug reports and pull requests are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to build, test, format, and document your changes, then open an issue using one of the templates. Make sure the test suite passes before submitting:
+
+```sh
+xcodebuild test -scheme SwipeMenuViewController -destination 'platform=iOS Simulator,name=iPhone 16'
+```
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Lowers the barrier to a first contribution by documenting the workflow that until now lived only in scattered README lines and CI files.

- **[`CONTRIBUTING.md`](CONTRIBUTING.md)**: requirements, project layout, how to build and test the package, how to generate and run the example app (XcodeGen), the `swift format` lint/format commands, the DocC build (`--warnings-as-errors`), and the changelog + pull-request conventions.
- **[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)**: a short checklist that mirrors what CI enforces (tests, formatter-clean, DocC for public API changes, changelog for user-facing changes).
- **README**: the Contributing section now links the guide and keeps the one-line test command.

## Notes

- Docs and template only — no source or CI changes.
- The guide's `swift format` section describes the tooling introduced in #163; that PR should merge first so the referenced `.swift-format` config is present on `main`.
- The example test command in the README keeps `iPhone 16` as an illustrative device name (any installed simulator works).